### PR TITLE
ADD: add dpos delegators reward allocate

### DIFF
--- a/common/bigint.go
+++ b/common/bigint.go
@@ -164,6 +164,20 @@ func (x BigInt) MultFloat64(y float64) (prod BigInt) {
 	return
 }
 
+// MulWithFloatResult will perform the multiplication operation between BigInt data and float64 data
+// and the result type is the rat
+func (x BigInt) MulWithFloatResult(y float64) (prod *big.Rat) {
+	// check if y is not a number, multiplication by 1
+	if math.IsNaN(y) {
+		y = 1
+	}
+
+	xRat := new(big.Rat).SetInt(&x.b)
+	yRat := new(big.Rat).SetFloat64(y)
+	prod = new(big.Rat).Mul(xRat, yRat)
+	return
+}
+
 // Div will perform the division operation between BigInt data
 func (x BigInt) Div(y BigInt) (quotient BigInt) {
 	// denominator cannot be 0

--- a/common/bigint.go
+++ b/common/bigint.go
@@ -164,20 +164,6 @@ func (x BigInt) MultFloat64(y float64) (prod BigInt) {
 	return
 }
 
-// MulWithFloatResult will perform the multiplication operation between BigInt data and float64 data
-// and the result type is the rat
-func (x BigInt) MulWithFloatResult(y float64) (prod *big.Rat) {
-	// check if y is not a number, multiplication by 1
-	if math.IsNaN(y) {
-		y = 1
-	}
-
-	xRat := new(big.Rat).SetInt(&x.b)
-	yRat := new(big.Rat).SetFloat64(y)
-	prod = new(big.Rat).Mul(xRat, yRat)
-	return
-}
-
 // Div will perform the division operation between BigInt data
 func (x BigInt) Div(y BigInt) (quotient BigInt) {
 	// denominator cannot be 0

--- a/consensus/dpos/dpos.go
+++ b/consensus/dpos/dpos.go
@@ -378,11 +378,10 @@ func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header 
 		state.AddBalance(header.Coinbase, blockReward)
 		return
 	}
-	voteCountRat := new(big.Rat).SetInt(voteCount.BigIntPtr())
 
 	// TODO get ratio of reward between delegate and voters
 	rewardRatio := defaultRewardRatio
-	delegatorReward := common.NewBigInt(blockReward.Int64()).Mult(rewardRatio).DivWithFloatResult(baseRewardDenominator)
+	delegatorReward := common.NewBigInt(blockReward.Int64()).Mult(rewardRatio).Div(baseRewardDenominator)
 	assignedReward := common.Big0
 
 	delegateTrie := dposContext.DelegateTrie()
@@ -394,9 +393,7 @@ func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header 
 		vote := common.NewBigInt(3)
 
 		// calculate reward of each delegator due to it's vote(stake) percent
-		x := vote.MulWithFloatResult(delegatorReward)
-		x.Quo(x, voteCountRat)
-		percentReward :=new(big.Int).Div(x.Num(), x.Denom())
+		percentReward := vote.Mult(delegatorReward).Div(voteCount).BigIntPtr()
 
 		state.AddBalance(delegator, percentReward)
 		assignedReward.Add(assignedReward, percentReward)


### PR DESCRIPTION
**Description**
Allocate the block reward to the validator and delegators belonged to it due to prior ratio. 

please refer to this doc：
http://md.dxchain.com/s/U8MrHC1sH

**Type of change**
- [x] New Feature

**Testing**
consensus/dpos/dpos_test.go:133

