### PR TITLE
FIX:The balance of the purchase of gas should be unfrozen assets.

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -154,7 +154,9 @@ func (st *StateTransition) useGas(amount uint64) error {
 
 func (st *StateTransition) buyGas() error {
 	mgval := new(big.Int).Mul(new(big.Int).SetUint64(st.msg.Gas()), st.gasPrice)
-	if st.state.GetBalance(st.msg.From()).Cmp(mgval) < 0 {
+
+	//The balance of the purchase of gas should be unfrozen assets.
+	if ok := CanTransfer(st.state, st.msg.From(), mgval); !ok {
 		return errInsufficientBalanceForGas
 	}
 	if err := st.gp.SubGas(st.msg.Gas()); err != nil {


### PR DESCRIPTION
## Description

* The required gas will be purchased in advance of the execution of the transaction, and the money required to purchase the purchase should not be the frozen asset. If the account transaction is cleared when all the balances of the account are frozen, although it is not possible to transfer funds, you can purchase the gas to consume and freeze the assets indefinitely.

## Type of change

- [X] Bug Fix (non-breaking change which fixes an issue)