### PR TITLE
Dpos epoch id delegate trie

### DIFF
--- a/common/bytes.go
+++ b/common/bytes.go
@@ -17,7 +17,10 @@
 // Package common contains various helper functions.
 package common
 
-import "encoding/hex"
+import (
+	"encoding/binary"
+	"encoding/hex"
+)
 
 // ToHex returns the hex representation of b, prefixed with '0x'.
 // For empty slices, the return value is "0x0".
@@ -135,4 +138,11 @@ func LeftPadBytes(slice []byte, l int) []byte {
 	copy(padded[l-len(slice):], slice)
 
 	return padded
+}
+
+// Int64ToBytes int64 to byte slice
+func Int64ToBytes(i int64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, uint64(i))
+	return b
 }

--- a/consensus/dpos/candidate.go
+++ b/consensus/dpos/candidate.go
@@ -35,13 +35,15 @@ func ProcessAddCandidate(state stateDB, ctx *types.DposContext, addr common.Addr
 
 // ProcessCancelCandidate cancel the addr being an candidate
 func ProcessCancelCandidate(state stateDB, ctx *types.DposContext, addr common.Address, time int64) error {
+	currentEpochID := CalculateEpochID(time)
+
 	// Kick out the candidate in DposContext
-	if err := ctx.KickoutCandidate(addr); err != nil {
+	if err := ctx.KickoutCandidate(addr, currentEpochID); err != nil {
 		return err
 	}
 	// Mark the thawing address in the future
 	prevDeposit := getCandidateDeposit(state, addr)
-	currentEpochID := CalculateEpochID(time)
+
 	markThawingAddressAndValue(state, addr, currentEpochID, prevDeposit)
 	// set the candidate deposit to 0
 	setCandidateDeposit(state, addr, common.BigInt0)

--- a/consensus/dpos/epoch_context.go
+++ b/consensus/dpos/epoch_context.go
@@ -155,7 +155,7 @@ func (ec *EpochContext) kickoutValidators(epoch int64) error {
 			log.Info("No more candidate can be kickout", "prevEpochID", epoch, "candidateCount", candidateCount, "needKickoutCount", len(needKickoutValidators)-i)
 			return nil
 		}
-		if err := ec.DposContext.KickoutCandidate(validator.address); err != nil {
+		if err := ec.DposContext.KickoutCandidate(validator.address, epoch); err != nil {
 			return err
 		}
 		// if successfully above, then mark the validator that will be thawed in next next epoch

--- a/consensus/dpos/epoch_context_test.go
+++ b/consensus/dpos/epoch_context_test.go
@@ -153,6 +153,8 @@ func Test_KickoutValidators(t *testing.T) {
 	}
 
 	epochID := CalculateEpochID(now)
+	epochIdBytes := common.Int64ToBytes(epochID)
+
 	err = epochContext.kickoutValidators(epochID)
 	if err != nil {
 		t.Errorf("something wrong to kick out validators,error: %v", err)
@@ -173,7 +175,7 @@ func Test_KickoutValidators(t *testing.T) {
 			t.Errorf("failed to delete the kick out one from candidate trie: %s", candidates[i].String())
 		}
 
-		delegatorFromTrie := epochContext.DposContext.DelegateTrie().Get(append(candidates[i].Bytes(), delegator.Bytes()...))
+		delegatorFromTrie := epochContext.DposContext.DelegateTrie().Get(append(epochIdBytes, append(candidates[i].Bytes(), delegator.Bytes()...)...))
 		if delegatorFromTrie != nil {
 			t.Errorf("failed to delete the kick out one from delegate trie: %s", candidates[i].String())
 		}

--- a/core/types/dpos_context.go
+++ b/core/types/dpos_context.go
@@ -229,7 +229,7 @@ func (dc *DposContext) KickoutCandidate(candidateAddr common.Address, epochID in
 	iter := trie.NewIterator(dc.delegateTrie.PrefixIterator(append(epochBytes, candidate...)))
 	for iter.Next() {
 		delegator := iter.Value
-		key := append(candidate, delegator...)
+		key := append(epochBytes, append(candidate, delegator...)...)
 		err = dc.delegateTrie.TryDelete(key)
 		if err != nil {
 			if _, ok := err.(*trie.MissingNodeError); !ok {


### PR DESCRIPTION
## Description

* Add epoch ID into the delegate trie as the prefix when it is updated, get, delete.
* Genesis block delegate  trie doesn't exist the prefix due to its epoch ID changing with user's setting in genesis.json.  

## Type of change

- [X] Bug Fix
- [X] New Feature

## Testing

Fix the incompatible bugs