### PR TITLE
ADD: add pre epoch snapshot delegate trie block number

### DIFF
--- a/consensus/dpos/dpos_test.go
+++ b/consensus/dpos/dpos_test.go
@@ -124,7 +124,7 @@ func TestAccumulateRewards(t *testing.T) {
 	expectedValidatorReward := big.NewInt(1.5e+18)
 
 	// allocate the block reward among validator and its delegators
-	accumulateRewards(params.MainnetChainConfig, stateDB, header, db, testChain)
+	accumulateRewards(params.MainnetChainConfig, stateDB, header, db, testChain.GetHeaderByNumber(0))
 	header.Root = stateDB.IntermediateRoot(params.MainnetChainConfig.IsEIP158(header.Number))
 
 	validatorBalance := stateDB.GetBalance(validator)
@@ -139,7 +139,7 @@ func TestAccumulateRewards(t *testing.T) {
 
 	// mock block sync
 	headerCopy := header
-	accumulateRewards(params.MainnetChainConfig, stateDbCopy, headerCopy, db, testChain)
+	accumulateRewards(params.MainnetChainConfig, stateDbCopy, headerCopy, db, testChain.GetHeaderByNumber(0))
 	headerCopy.Root = stateDB.IntermediateRoot(params.MainnetChainConfig.IsEIP158(headerCopy.Number))
 
 	if header.Root != headerCopy.Root {

--- a/consensus/dpos/epoch_context.go
+++ b/consensus/dpos/epoch_context.go
@@ -45,6 +45,9 @@ func (ec *EpochContext) tryElect(genesis, parent *types.Header) error {
 		return nil
 	}
 
+	// set the snapshot delegate trie block number for accumulateRewards
+	setPreEpochSnapshotDelegateTrieBlockNumber(ec.stateDB, common.NewBigIntUint64(parent.Number.Uint64()+1))
+
 	prevEpochBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(prevEpochBytes, uint64(prevEpoch))
 	iter := trie.NewIterator(ec.DposContext.MinedCntTrie().PrefixIterator(prevEpochBytes))

--- a/consensus/dpos/epoch_context.go
+++ b/consensus/dpos/epoch_context.go
@@ -45,9 +45,6 @@ func (ec *EpochContext) tryElect(genesis, parent *types.Header) error {
 		return nil
 	}
 
-	// set the snapshot delegate trie block number for accumulateRewards
-	setPreEpochSnapshotDelegateTrieBlockNumber(ec.stateDB, common.NewBigIntUint64(parent.Number.Uint64()+1))
-
 	prevEpochBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(prevEpochBytes, uint64(prevEpoch))
 	iter := trie.NewIterator(ec.DposContext.MinedCntTrie().PrefixIterator(prevEpochBytes))
@@ -97,6 +94,9 @@ func (ec *EpochContext) tryElect(genesis, parent *types.Header) error {
 		}
 		log.Info("Come to new epoch", "prevEpoch", i, "nextEpoch", i+1)
 	}
+
+	// Finally, set the snapshot delegate trie root for accumulateRewards
+	setPreEpochSnapshotDelegateTrieRoot(ec.stateDB, ec.DposContext.DelegateTrie().Hash())
 	return nil
 }
 

--- a/consensus/dpos/state.go
+++ b/consensus/dpos/state.go
@@ -6,6 +6,7 @@ package dpos
 
 import (
 	"encoding/binary"
+	"github.com/DxChainNetwork/godx/core/types"
 	"math/big"
 
 	"github.com/DxChainNetwork/godx/common"
@@ -17,6 +18,7 @@ type stateDB interface {
 	ForEachStorage(addr common.Address, cb func(common.Hash, common.Hash) bool) error
 	Exist(addr common.Address) bool
 	CreateAccount(addr common.Address)
+	GetNonce(common.Address) uint64
 	SetNonce(addr common.Address, nonce uint64)
 	GetBalance(addr common.Address) *big.Int
 }
@@ -47,8 +49,8 @@ var (
 	// PrefixThawingAssets is the prefix recording the amount to be thawed in a specified epoch
 	PrefixThawingAssets = []byte("thawing-assets")
 
-	// KeyPreEpochSnapshotDelegateTrieBlockNumber is the key of block number where snapshot delegate trie
-	KeyPreEpochSnapshotDelegateTrieBlockNumber = common.BytesToHash([]byte("pre-epoch-bn"))
+	// KeyPreEpochSnapshotDelegateTrieRoot is the key of block number where snapshot delegate trie
+	KeyPreEpochSnapshotDelegateTrieRoot = common.BytesToHash([]byte("pre-epoch-dtr"))
 
 	// KeyValueCommonAddress is the address for some common key-value storage
 	KeyValueCommonAddress = common.BigToAddress(big.NewInt(0))
@@ -214,17 +216,17 @@ func removeAddressInState(state stateDB, addr common.Address) {
 	state.SetNonce(addr, 0)
 }
 
-// getPreEpochSnapshotDelegateTrieBlockNumber get the block number of snapshot delegate trie
-func getPreEpochSnapshotDelegateTrieBlockNumber(state stateDB) common.BigInt {
-	h := state.GetState(KeyValueCommonAddress, KeyPreEpochSnapshotDelegateTrieBlockNumber)
-	if h == (common.Hash{}) {
-		return common.BigInt0
+// getPreEpochSnapshotDelegateTrieRoot get the block number of snapshot delegate trie
+func getPreEpochSnapshotDelegateTrieRoot(state stateDB, genesis *types.Header) common.Hash {
+	h := state.GetState(KeyValueCommonAddress, KeyPreEpochSnapshotDelegateTrieRoot)
+	if h == types.EmptyHash {
+		h = genesis.DposContext.DelegateRoot
 	}
-	return common.PtrBigInt(h.Big())
+	return h
 }
 
-// setPreEpochSnapshotDelegateTrieBlockNumber set the block number of snapshot delegate trie
-func setPreEpochSnapshotDelegateTrieBlockNumber(state stateDB, value common.BigInt) {
-	h := common.BigToHash(value.BigIntPtr())
-	state.SetState(KeyValueCommonAddress, KeyPreEpochSnapshotDelegateTrieBlockNumber, h)
+// setPreEpochSnapshotDelegateTrieRoot set the block number of snapshot delegate trie
+func setPreEpochSnapshotDelegateTrieRoot(state stateDB, value common.Hash) {
+	state.SetNonce(KeyValueCommonAddress, state.GetNonce(KeyValueCommonAddress)+1)
+	state.SetState(KeyValueCommonAddress, KeyPreEpochSnapshotDelegateTrieRoot, value)
 }

--- a/consensus/dpos/state.go
+++ b/consensus/dpos/state.go
@@ -46,6 +46,12 @@ var (
 
 	// PrefixThawingAssets is the prefix recording the amount to be thawed in a specified epoch
 	PrefixThawingAssets = []byte("thawing-assets")
+
+	// KeyPreEpochSnapshotDelegateTrieBlockNumber is the key of block number where snapshot delegate trie
+	KeyPreEpochSnapshotDelegateTrieBlockNumber = common.BytesToHash([]byte("pre-epoch-bn"))
+
+	// KeyValueCommonAddress is the address for some common key-value storage
+	KeyValueCommonAddress = common.BigToAddress(big.NewInt(0))
 )
 
 // getCandidateDeposit get the candidates deposit of the addr from the state
@@ -206,4 +212,19 @@ func setVoteLastEpoch(state stateDB, addr common.Address, value common.BigInt) {
 // If this is the case, simply leave the address there.
 func removeAddressInState(state stateDB, addr common.Address) {
 	state.SetNonce(addr, 0)
+}
+
+// getPreEpochSnapshotDelegateTrieBlockNumber get the block number of snapshot delegate trie
+func getPreEpochSnapshotDelegateTrieBlockNumber(state stateDB) common.BigInt {
+	h := state.GetState(KeyValueCommonAddress, KeyPreEpochSnapshotDelegateTrieBlockNumber)
+	if h == (common.Hash{}) {
+		return common.BigInt0
+	}
+	return common.PtrBigInt(h.Big())
+}
+
+// setPreEpochSnapshotDelegateTrieBlockNumber set the block number of snapshot delegate trie
+func setPreEpochSnapshotDelegateTrieBlockNumber(state stateDB, value common.BigInt) {
+	h := common.BigToHash(value.BigIntPtr())
+	state.SetState(KeyValueCommonAddress, KeyPreEpochSnapshotDelegateTrieBlockNumber, h)
 }

--- a/consensus/dpos/state.go
+++ b/consensus/dpos/state.go
@@ -6,10 +6,10 @@ package dpos
 
 import (
 	"encoding/binary"
-	"github.com/DxChainNetwork/godx/core/types"
 	"math/big"
 
 	"github.com/DxChainNetwork/godx/common"
+	"github.com/DxChainNetwork/godx/core/types"
 )
 
 type stateDB interface {

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -243,6 +243,10 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 		panic(err)
 	}
 
+	// init the KeyValueCommonAddress account and set its nonce 1 to avoid deleting empty state object
+	statedb.SetNonce(dpos.KeyValueCommonAddress, 1)
+	statedb.SetState(dpos.KeyValueCommonAddress, dpos.KeyPreEpochSnapshotDelegateTrieRoot, dposContext.DelegateTrie().Hash())
+
 	root := statedb.IntermediateRoot(false)
 	dcProto := dposContext.ToRoot()
 	head := &types.Header{

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -41,7 +41,7 @@ func TestDefaultGenesisBlock(t *testing.T) {
 
 func TestSetupGenesis(t *testing.T) {
 	var (
-		customghash = common.HexToHash("0x2cd8b8f753cd80d29b566e5a7bc0d50465480888482cd75e3a784d77a039ef2f")
+		customghash = common.HexToHash("0xa462c4d000329fe2b7e508cc459910227f2b76195e74407961fa34fbbec39514")
 		customg     = Genesis{
 			Config: params.DposChainConfig,
 			Alloc: GenesisAlloc{

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -41,7 +41,7 @@ func TestDefaultGenesisBlock(t *testing.T) {
 
 func TestSetupGenesis(t *testing.T) {
 	var (
-		customghash = common.HexToHash("0xa462c4d000329fe2b7e508cc459910227f2b76195e74407961fa34fbbec39514")
+		customghash = common.HexToHash("0x03c80021f8764fedba6521a332154018c27cd8686bd39511e36b85e334376f62")
 		customg     = Genesis{
 			Config: params.DposChainConfig,
 			Alloc: GenesisAlloc{

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -37,6 +37,7 @@ import (
 var (
 	EmptyRootHash  = DeriveSha(Transactions{})
 	EmptyUncleHash = CalcUncleHash(nil)
+	EmptyHash      = common.Hash{}
 )
 
 // A BlockNonce is a 64-bit hash which proves (combined with the

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -266,7 +266,7 @@ func TestStreamUncleBlock(t *testing.T) {
 
 	select {
 	case <-taskCh:
-	case <-time.NewTimer(time.Second).C:
+	case <-time.NewTimer(5 * time.Second).C:
 		t.Error("new task timeout")
 	}
 }

--- a/params/config.go
+++ b/params/config.go
@@ -25,8 +25,8 @@ import (
 
 // Genesis hashes to enforce below configs on.
 var (
-	MainnetGenesisHash = common.HexToHash("0x87155ef8a2d887ebd571beb022e6a9d33f25f1c49e33bbaebc25937813c02416")
-	TestnetGenesisHash = common.HexToHash("0x101495c2096316b37db8028b34d56b664d4e0f0bb33288756aafaa99fd40b383")
+	MainnetGenesisHash = common.HexToHash("ce76b8a1692d04827d3fc98b10878288522611feb477e5cc9f3cc501b28745bc")
+	TestnetGenesisHash = common.HexToHash("a3d7d67c50ad20df8e382101b8c4dccd5f87f68c33975e46161b20df7ae9743f")
 	RinkebyGenesisHash = common.HexToHash("0x6341fd3daf94b748c72ced5a5b26028f2474f5f00d824504e4fa37a75767e177")
 )
 

--- a/params/config.go
+++ b/params/config.go
@@ -25,8 +25,8 @@ import (
 
 // Genesis hashes to enforce below configs on.
 var (
-	MainnetGenesisHash = common.HexToHash("ce76b8a1692d04827d3fc98b10878288522611feb477e5cc9f3cc501b28745bc")
-	TestnetGenesisHash = common.HexToHash("a3d7d67c50ad20df8e382101b8c4dccd5f87f68c33975e46161b20df7ae9743f")
+	MainnetGenesisHash = common.HexToHash("27507964589162c42b35ff39be24f9944b845e00d7ae298793c0e60f3f96e9c8")
+	TestnetGenesisHash = common.HexToHash("90d435660a79293bfa13401cfd415f18ddd7d0baebaa33a8caf5425837e7033d")
 	RinkebyGenesisHash = common.HexToHash("0x6341fd3daf94b748c72ced5a5b26028f2474f5f00d824504e4fa37a75767e177")
 )
 


### PR DESCRIPTION
## Description

* Remove epoch ID in the delegate trie due to maintenance complexity 
* Storage last block number of previous epoch in state, and then recover delegate trie through delegate root in that block Header 

## Type of change

- [X] Bug Fix
- [X] New Feature

## Testing

Fix the incompatible bugs