### PR TITLE
Light node: insert header chain

### DIFF
--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -255,9 +255,11 @@ func (c *Clique) VerifyHeader(chain consensus.ChainReader, header *types.Header,
 // VerifyHeaders is similar to VerifyHeader, but verifies a batch of headers. The
 // method returns a quit channel to abort the operations and a results channel to
 // retrieve the async verifications (the order is that of the input slice).
-func (c *Clique) VerifyHeaders(chain consensus.ChainReader, headers []*types.Header, validators []common.Address, seals []bool) (chan<- struct{}, <-chan error) {
+func (c *Clique) VerifyHeaders(chain consensus.ChainReader, data types.HeaderInsertDataBatch, seals []bool) (chan<- struct{}, <-chan error) {
 	abort := make(chan struct{})
-	results := make(chan error, len(headers))
+	results := make(chan error, len(data))
+
+	headers, _ := data.Split()
 
 	go func() {
 		for i, header := range headers {

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -255,7 +255,7 @@ func (c *Clique) VerifyHeader(chain consensus.ChainReader, header *types.Header,
 // VerifyHeaders is similar to VerifyHeader, but verifies a batch of headers. The
 // method returns a quit channel to abort the operations and a results channel to
 // retrieve the async verifications (the order is that of the input slice).
-func (c *Clique) VerifyHeaders(chain consensus.ChainReader, headers []*types.Header, seals []bool) (chan<- struct{}, <-chan error) {
+func (c *Clique) VerifyHeaders(chain consensus.ChainReader, headers []*types.Header, validators []common.Address, seals []bool) (chan<- struct{}, <-chan error) {
 	abort := make(chan struct{})
 	results := make(chan error, len(headers))
 

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -68,7 +68,7 @@ type Engine interface {
 	// concurrently. The method returns a quit channel to abort the operations and
 	// a results channel to retrieve the async verifications (the order is that of
 	// the input slice).
-	VerifyHeaders(chain ChainReader, headers []*types.Header, seals []bool) (chan<- struct{}, <-chan error)
+	VerifyHeaders(chain ChainReader, headers []*types.Header, validators []common.Address, seals []bool) (chan<- struct{}, <-chan error)
 
 	// VerifyUncles verifies that the given block's uncles conform to the consensus
 	// rules of a given engine.

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -68,7 +68,7 @@ type Engine interface {
 	// concurrently. The method returns a quit channel to abort the operations and
 	// a results channel to retrieve the async verifications (the order is that of
 	// the input slice).
-	VerifyHeaders(chain ChainReader, headers []*types.Header, validators []common.Address, seals []bool) (chan<- struct{}, <-chan error)
+	VerifyHeaders(chain ChainReader, data types.HeaderInsertDataBatch, seals []bool) (chan<- struct{}, <-chan error)
 
 	// VerifyUncles verifies that the given block's uncles conform to the consensus
 	// rules of a given engine.

--- a/consensus/dpos/api.go
+++ b/consensus/dpos/api.go
@@ -47,7 +47,7 @@ func (api *API) GetConfirmedBlockNumber() (*big.Int, error) {
 // GetValidators will return the validator list based on the block header provided
 func GetValidators(diskdb ethdb.Database, header *types.Header) ([]common.Address, error) {
 	// re-construct trieDB and get the epochTrie
-	epochTrie, err := types.NewFullDposDatabase(diskdb).OpenTrie(header.DposContext.EpochRoot)
+	epochTrie, err := types.NewFullDposDatabase(diskdb).OpenEpochTrie(header.DposContext.EpochRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to recover the epochTrie based on the root: %s", err.Error())
 	}
@@ -78,7 +78,7 @@ func IsValidator(diskdb ethdb.Database, header *types.Header, addr common.Addres
 // GetCandidates will return the candidates list based on the block header provided
 func GetCandidates(diskdb ethdb.Database, header *types.Header) ([]common.Address, error) {
 	// re-construct trieDB and get the candidateTrie
-	candidateTrie, err := types.NewFullDposDatabase(diskdb).OpenTrie(header.DposContext.CandidateRoot)
+	candidateTrie, err := types.NewFullDposDatabase(diskdb).OpenCandidateTrie(header.DposContext.CandidateRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to recover the candidateTrie based on the root: %s", err.Error())
 	}
@@ -109,7 +109,7 @@ func GetCandidateInfo(stateDb *state.StateDB, candidateAddress common.Address, h
 	candidateDeposit := GetCandidateDeposit(stateDb, candidateAddress)
 
 	// get the candidateTrie
-	delegateTrie, err := types.NewFullDposDatabase(diskdb).OpenTrie(header.DposContext.DelegateRoot)
+	delegateTrie, err := types.NewFullDposDatabase(diskdb).OpenDelegateTrie(header.DposContext.DelegateRoot)
 	if err != nil {
 		return common.BigInt0, common.BigInt0, 0, fmt.Errorf("failed to recover the candidateTrie based on the root: %s", err.Error())
 	}
@@ -122,7 +122,7 @@ func GetCandidateInfo(stateDb *state.StateDB, candidateAddress common.Address, h
 // getMinedBlocksCount will return the number of blocks mined by the validator within the current epoch
 func getMinedBlocksCount(diskdb ethdb.Database, header *types.Header, validatorAddress common.Address) (int64, error) {
 	// re-construct the minedCntTrie
-	minedCntTrie, err := types.NewFullDposDatabase(diskdb).OpenTrie(header.DposContext.MinedCntRoot)
+	minedCntTrie, err := types.NewFullDposDatabase(diskdb).OpenMinedCntTrie(header.DposContext.MinedCntRoot)
 	if err != nil {
 		return 0, fmt.Errorf("failed to recover the minedCntTrie based on the root: %s", err.Error())
 	}

--- a/consensus/dpos/api.go
+++ b/consensus/dpos/api.go
@@ -13,7 +13,6 @@ import (
 	"github.com/DxChainNetwork/godx/core/state"
 	"github.com/DxChainNetwork/godx/core/types"
 	"github.com/DxChainNetwork/godx/ethdb"
-	"github.com/DxChainNetwork/godx/trie"
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
@@ -48,8 +47,7 @@ func (api *API) GetConfirmedBlockNumber() (*big.Int, error) {
 // GetValidators will return the validator list based on the block header provided
 func GetValidators(diskdb ethdb.Database, header *types.Header) ([]common.Address, error) {
 	// re-construct trieDB and get the epochTrie
-	trieDb := trie.NewDatabase(diskdb)
-	epochTrie, err := types.NewEpochTrie(header.DposContext.EpochRoot, trieDb)
+	epochTrie, err := types.NewDposDb(diskdb).OpenTrie(header.DposContext.EpochRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to recover the epochTrie based on the root: %s", err.Error())
 	}
@@ -80,8 +78,7 @@ func IsValidator(diskdb ethdb.Database, header *types.Header, addr common.Addres
 // GetCandidates will return the candidates list based on the block header provided
 func GetCandidates(diskdb ethdb.Database, header *types.Header) ([]common.Address, error) {
 	// re-construct trieDB and get the candidateTrie
-	trieDb := trie.NewDatabase(diskdb)
-	candidateTrie, err := types.NewCandidateTrie(header.DposContext.CandidateRoot, trieDb)
+	candidateTrie, err := types.NewDposDb(diskdb).OpenTrie(header.DposContext.CandidateRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to recover the candidateTrie based on the root: %s", err.Error())
 	}
@@ -107,12 +104,12 @@ func GetValidatorInfo(stateDb *state.StateDB, validatorAddress common.Address, d
 }
 
 // GetCandidateInfo will return the detailed candidates information
-func GetCandidateInfo(stateDb *state.StateDB, candidateAddress common.Address, header *types.Header, trieDb *trie.Database) (common.BigInt, common.BigInt, uint64, error) {
+func GetCandidateInfo(stateDb *state.StateDB, candidateAddress common.Address, header *types.Header, diskdb ethdb.Database) (common.BigInt, common.BigInt, uint64, error) {
 	// get detailed candidates information
 	candidateDeposit := GetCandidateDeposit(stateDb, candidateAddress)
 
 	// get the candidateTrie
-	delegateTrie, err := types.NewDelegateTrie(header.DposContext.DelegateRoot, trieDb)
+	delegateTrie, err := types.NewDposDb(diskdb).OpenTrie(header.DposContext.DelegateRoot)
 	if err != nil {
 		return common.BigInt0, common.BigInt0, 0, fmt.Errorf("failed to recover the candidateTrie based on the root: %s", err.Error())
 	}
@@ -125,8 +122,7 @@ func GetCandidateInfo(stateDb *state.StateDB, candidateAddress common.Address, h
 // getMinedBlocksCount will return the number of blocks mined by the validator within the current epoch
 func getMinedBlocksCount(diskdb ethdb.Database, header *types.Header, validatorAddress common.Address) (int64, error) {
 	// re-construct the minedCntTrie
-	trieDb := trie.NewDatabase(diskdb)
-	minedCntTrie, err := types.NewMinedCntTrie(header.DposContext.MinedCntRoot, trieDb)
+	minedCntTrie, err := types.NewDposDb(diskdb).OpenTrie(header.DposContext.MinedCntRoot)
 	if err != nil {
 		return 0, fmt.Errorf("failed to recover the minedCntTrie based on the root: %s", err.Error())
 	}

--- a/consensus/dpos/api.go
+++ b/consensus/dpos/api.go
@@ -47,7 +47,7 @@ func (api *API) GetConfirmedBlockNumber() (*big.Int, error) {
 // GetValidators will return the validator list based on the block header provided
 func GetValidators(diskdb ethdb.Database, header *types.Header) ([]common.Address, error) {
 	// re-construct trieDB and get the epochTrie
-	epochTrie, err := types.NewDposDb(diskdb).OpenTrie(header.DposContext.EpochRoot)
+	epochTrie, err := types.NewFullDposDatabase(diskdb).OpenTrie(header.DposContext.EpochRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to recover the epochTrie based on the root: %s", err.Error())
 	}
@@ -78,7 +78,7 @@ func IsValidator(diskdb ethdb.Database, header *types.Header, addr common.Addres
 // GetCandidates will return the candidates list based on the block header provided
 func GetCandidates(diskdb ethdb.Database, header *types.Header) ([]common.Address, error) {
 	// re-construct trieDB and get the candidateTrie
-	candidateTrie, err := types.NewDposDb(diskdb).OpenTrie(header.DposContext.CandidateRoot)
+	candidateTrie, err := types.NewFullDposDatabase(diskdb).OpenTrie(header.DposContext.CandidateRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to recover the candidateTrie based on the root: %s", err.Error())
 	}
@@ -109,7 +109,7 @@ func GetCandidateInfo(stateDb *state.StateDB, candidateAddress common.Address, h
 	candidateDeposit := GetCandidateDeposit(stateDb, candidateAddress)
 
 	// get the candidateTrie
-	delegateTrie, err := types.NewDposDb(diskdb).OpenTrie(header.DposContext.DelegateRoot)
+	delegateTrie, err := types.NewFullDposDatabase(diskdb).OpenTrie(header.DposContext.DelegateRoot)
 	if err != nil {
 		return common.BigInt0, common.BigInt0, 0, fmt.Errorf("failed to recover the candidateTrie based on the root: %s", err.Error())
 	}
@@ -122,7 +122,7 @@ func GetCandidateInfo(stateDb *state.StateDB, candidateAddress common.Address, h
 // getMinedBlocksCount will return the number of blocks mined by the validator within the current epoch
 func getMinedBlocksCount(diskdb ethdb.Database, header *types.Header, validatorAddress common.Address) (int64, error) {
 	// re-construct the minedCntTrie
-	minedCntTrie, err := types.NewDposDb(diskdb).OpenTrie(header.DposContext.MinedCntRoot)
+	minedCntTrie, err := types.NewFullDposDatabase(diskdb).OpenTrie(header.DposContext.MinedCntRoot)
 	if err != nil {
 		return 0, fmt.Errorf("failed to recover the minedCntTrie based on the root: %s", err.Error())
 	}

--- a/consensus/dpos/candidate.go
+++ b/consensus/dpos/candidate.go
@@ -58,7 +58,7 @@ func CandidateTxDataValidation(state stateDB, data types.AddCandidateTxData, can
 // IsCandidate will check whether or not the given address is a candidate address
 func IsCandidate(candidateAddress common.Address, header *types.Header, diskDB ethdb.Database) bool {
 	// re-construct trieDB and get the candidateTrie
-	candidateTrie, err := types.NewDposDb(diskDB).OpenTrie(header.DposContext.CandidateRoot)
+	candidateTrie, err := types.NewFullDposDatabase(diskDB).OpenTrie(header.DposContext.CandidateRoot)
 	if err != nil {
 		return false
 	}

--- a/consensus/dpos/candidate.go
+++ b/consensus/dpos/candidate.go
@@ -58,8 +58,7 @@ func CandidateTxDataValidation(state stateDB, data types.AddCandidateTxData, can
 // IsCandidate will check whether or not the given address is a candidate address
 func IsCandidate(candidateAddress common.Address, header *types.Header, diskDB ethdb.Database) bool {
 	// re-construct trieDB and get the candidateTrie
-	trieDb := trie.NewDatabase(diskDB)
-	candidateTrie, err := types.NewCandidateTrie(header.DposContext.CandidateRoot, trieDb)
+	candidateTrie, err := types.NewDposDb(diskDB).OpenTrie(header.DposContext.CandidateRoot)
 	if err != nil {
 		return false
 	}

--- a/consensus/dpos/candidate.go
+++ b/consensus/dpos/candidate.go
@@ -66,7 +66,7 @@ func IsCandidate(candidateAddress common.Address, header *types.Header, diskDB e
 }
 
 // isCandidate determines whether the addr is a candidate from a candidateTrie
-func isCandidate(candidateTrie *trie.Trie, addr common.Address) bool {
+func isCandidate(candidateTrie types.DposTrie, addr common.Address) bool {
 	// check if the candidate exists
 	if value, err := candidateTrie.TryGet(addr.Bytes()); err != nil || value == nil {
 		return false
@@ -76,7 +76,7 @@ func isCandidate(candidateTrie *trie.Trie, addr common.Address) bool {
 
 // CalcCandidateTotalVotes calculate the total votes for the candidates. The result include the deposit for the
 // candidates himself and the delegated votes from delegator
-func CalcCandidateTotalVotes(candidateAddr common.Address, state stateDB, delegateTrie *trie.Trie) common.BigInt {
+func CalcCandidateTotalVotes(candidateAddr common.Address, state stateDB, delegateTrie types.DposTrie) common.BigInt {
 	// Calculate the candidates deposit and delegatedVote
 	candidateDeposit := GetCandidateDeposit(state, candidateAddr)
 	delegatedVote := calcCandidateDelegatedVotes(state, candidateAddr, delegateTrie)
@@ -85,7 +85,7 @@ func CalcCandidateTotalVotes(candidateAddr common.Address, state stateDB, delega
 }
 
 // calcCandidateDelegatedVotes calculate the total votes from delegator for the candidates in the current dposContext
-func calcCandidateDelegatedVotes(state stateDB, candidateAddr common.Address, dt *trie.Trie) common.BigInt {
+func calcCandidateDelegatedVotes(state stateDB, candidateAddr common.Address, dt types.DposTrie) common.BigInt {
 	delegateIterator := trie.NewIterator(dt.PrefixIterator(candidateAddr.Bytes()))
 	// loop through each delegator, get all votes
 	delegatorVotes := common.BigInt0

--- a/consensus/dpos/candidate.go
+++ b/consensus/dpos/candidate.go
@@ -58,7 +58,7 @@ func CandidateTxDataValidation(state stateDB, data types.AddCandidateTxData, can
 // IsCandidate will check whether or not the given address is a candidate address
 func IsCandidate(candidateAddress common.Address, header *types.Header, diskDB ethdb.Database) bool {
 	// re-construct trieDB and get the candidateTrie
-	candidateTrie, err := types.NewFullDposDatabase(diskDB).OpenTrie(header.DposContext.CandidateRoot)
+	candidateTrie, err := types.NewFullDposDatabase(diskDB).OpenCandidateTrie(header.DposContext.CandidateRoot)
 	if err != nil {
 		return false
 	}

--- a/consensus/dpos/delegator.go
+++ b/consensus/dpos/delegator.go
@@ -65,7 +65,7 @@ func VoteTxDepositValidation(state stateDB, delegatorAddress common.Address, vot
 // HasVoted will check whether the provided delegator address is voted
 func HasVoted(delegatorAddress common.Address, header *types.Header, diskDB ethdb.Database) bool {
 	// re-construct trieDB and get the voteTrie
-	voteTrie, err := types.NewDposDb(diskDB).OpenTrie(header.DposContext.VoteRoot)
+	voteTrie, err := types.NewFullDposDatabase(diskDB).OpenTrie(header.DposContext.VoteRoot)
 	if err != nil {
 		return false
 	}

--- a/consensus/dpos/delegator.go
+++ b/consensus/dpos/delegator.go
@@ -65,7 +65,7 @@ func VoteTxDepositValidation(state stateDB, delegatorAddress common.Address, vot
 // HasVoted will check whether the provided delegator address is voted
 func HasVoted(delegatorAddress common.Address, header *types.Header, diskDB ethdb.Database) bool {
 	// re-construct trieDB and get the voteTrie
-	voteTrie, err := types.NewFullDposDatabase(diskDB).OpenTrie(header.DposContext.VoteRoot)
+	voteTrie, err := types.NewFullDposDatabase(diskDB).OpenVoteTrie(header.DposContext.VoteRoot)
 	if err != nil {
 		return false
 	}

--- a/consensus/dpos/delegator.go
+++ b/consensus/dpos/delegator.go
@@ -8,7 +8,6 @@ import (
 	"github.com/DxChainNetwork/godx/common"
 	"github.com/DxChainNetwork/godx/core/types"
 	"github.com/DxChainNetwork/godx/ethdb"
-	"github.com/DxChainNetwork/godx/trie"
 )
 
 // ProcessVote process the process request for state and dpos context
@@ -66,8 +65,7 @@ func VoteTxDepositValidation(state stateDB, delegatorAddress common.Address, vot
 // HasVoted will check whether the provided delegator address is voted
 func HasVoted(delegatorAddress common.Address, header *types.Header, diskDB ethdb.Database) bool {
 	// re-construct trieDB and get the voteTrie
-	trieDb := trie.NewDatabase(diskDB)
-	voteTrie, err := types.NewVoteTrie(header.DposContext.VoteRoot, trieDb)
+	voteTrie, err := types.NewDposDb(diskDB).OpenTrie(header.DposContext.VoteRoot)
 	if err != nil {
 		return false
 	}

--- a/consensus/dpos/dpos.go
+++ b/consensus/dpos/dpos.go
@@ -250,7 +250,7 @@ func (d *Dpos) verifySeal(chain consensus.ChainReader, header *types.Header, par
 	} else {
 		parent = chain.GetHeader(header.ParentHash, number-1)
 	}
-	dposContext, err := types.NewDposContextFromProto(d.db, parent.DposContext)
+	dposContext, err := types.NewDposContextFromProto(types.NewDposDb(d.db), parent.DposContext)
 	if err != nil {
 		return err
 	}
@@ -361,7 +361,7 @@ func (d *Dpos) Prepare(chain consensus.ChainReader, header *types.Header) error 
 }
 
 // accumulateRewards add the block award to Coinbase of validator
-func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header *types.Header, db *trie.Database, genesis *types.Header) {
+func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header *types.Header, db ethdb.Database, genesis *types.Header) {
 	// Select the correct block reward based on chain progression
 	blockReward := frontierBlockReward
 	if config.IsByzantium(header.Number) {
@@ -383,7 +383,7 @@ func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header 
 
 	// Loop over the delegators to add delegator rewards
 	preEpochSnapshotDelegateTrieRoot := getPreEpochSnapshotDelegateTrieRoot(state, genesis)
-	delegateTrie, err := getPreEpochSnapshotDelegateTrie(db, preEpochSnapshotDelegateTrieRoot)
+	delegateTrie, err := getPreEpochSnapshotDelegateTrie(types.NewDposDb(db), preEpochSnapshotDelegateTrieRoot)
 	if err != nil {
 		log.Error("couldn't get snapshot delegate trie, error:", err)
 		return
@@ -409,7 +409,7 @@ func (d *Dpos) Finalize(chain consensus.ChainReader, header *types.Header, state
 	uncles []*types.Header, receipts []*types.Receipt, dposContext *types.DposContext) (*types.Block, error) {
 	// Accumulate block rewards and commit the final state root
 	genesis := chain.GetHeaderByNumber(0)
-	accumulateRewards(chain.Config(), state, header, trie.NewDatabase(d.db), genesis)
+	accumulateRewards(chain.Config(), state, header, d.db, genesis)
 
 	if d.Mode == ModeFake {
 		header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
@@ -465,7 +465,7 @@ func (d *Dpos) CheckValidator(lastBlock *types.Block, now int64) error {
 	if err := d.checkDeadline(lastBlock, now); err != nil {
 		return err
 	}
-	dposContext, err := types.NewDposContextFromProto(d.db, lastBlock.Header().DposContext)
+	dposContext, err := types.NewDposContextFromProto(types.NewDposDb(d.db), lastBlock.Header().DposContext)
 	if err != nil {
 		return err
 	}
@@ -602,8 +602,8 @@ func updateMinedCnt(parentBlockTime int64, validator common.Address, dposContext
 }
 
 // getPreEpochSnapshotDelegateTrie get the snapshot delegate trie of pre epoch
-func getPreEpochSnapshotDelegateTrie(db *trie.Database, root common.Hash) (*trie.Trie, error) {
-	return types.NewDelegateTrie(root, db)
+func getPreEpochSnapshotDelegateTrie(db types.DposDatabase, root common.Hash) (*trie.Trie, error) {
+	return db.OpenTrie(root)
 }
 
 func setMinedCnt(minedCntTrie *trie.Trie, epoch int64, validator common.Address, value uint64) error {

--- a/consensus/dpos/dpos.go
+++ b/consensus/dpos/dpos.go
@@ -250,7 +250,7 @@ func (d *Dpos) verifySeal(chain consensus.ChainReader, header *types.Header, par
 	} else {
 		parent = chain.GetHeader(header.ParentHash, number-1)
 	}
-	dposContext, err := types.NewDposContextFromProto(types.NewDposDb(d.db), parent.DposContext)
+	dposContext, err := types.NewDposContextFromProto(types.NewFullDposDatabase(d.db), parent.DposContext)
 	if err != nil {
 		return err
 	}
@@ -383,7 +383,7 @@ func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header 
 
 	// Loop over the delegators to add delegator rewards
 	preEpochSnapshotDelegateTrieRoot := getPreEpochSnapshotDelegateTrieRoot(state, genesis)
-	delegateTrie, err := getPreEpochSnapshotDelegateTrie(types.NewDposDb(db), preEpochSnapshotDelegateTrieRoot)
+	delegateTrie, err := getPreEpochSnapshotDelegateTrie(types.NewFullDposDatabase(db), preEpochSnapshotDelegateTrieRoot)
 	if err != nil {
 		log.Error("couldn't get snapshot delegate trie, error:", err)
 		return
@@ -465,7 +465,7 @@ func (d *Dpos) CheckValidator(lastBlock *types.Block, now int64) error {
 	if err := d.checkDeadline(lastBlock, now); err != nil {
 		return err
 	}
-	dposContext, err := types.NewDposContextFromProto(types.NewDposDb(d.db), lastBlock.Header().DposContext)
+	dposContext, err := types.NewDposContextFromProto(types.NewFullDposDatabase(d.db), lastBlock.Header().DposContext)
 	if err != nil {
 		return err
 	}
@@ -603,7 +603,7 @@ func updateMinedCnt(parentBlockTime int64, validator common.Address, dposContext
 
 // getPreEpochSnapshotDelegateTrie get the snapshot delegate trie of pre epoch
 func getPreEpochSnapshotDelegateTrie(db types.DposDatabase, root common.Hash) (*trie.Trie, error) {
-	return db.OpenTrie(root)
+	return db.OpenEpochTrie(root)
 }
 
 func setMinedCnt(minedCntTrie *trie.Trie, epoch int64, validator common.Address, value uint64) error {

--- a/consensus/dpos/dpos.go
+++ b/consensus/dpos/dpos.go
@@ -198,7 +198,7 @@ func (d *Dpos) verifyHeader(chain consensus.ChainReader, header *types.Header, v
 	}
 	var vGetter validatorHelper
 	if len(validators) != 0 {
-		vGetter = newVHelper(validators, header, d.db)
+		vGetter = newVHelper(validators, header)
 	} else {
 		vGetter = newDBVHelper(d.db, parent, header)
 	}
@@ -663,14 +663,12 @@ type validatorHelper interface {
 type vHelper struct {
 	validators []common.Address
 	header     *types.Header
-	db         ethdb.Database
 }
 
-func newVHelper(validators []common.Address, header *types.Header, db ethdb.Database) *vHelper {
+func newVHelper(validators []common.Address, header *types.Header) *vHelper {
 	return &vHelper{
 		validators: validators,
 		header:     header,
-		db:         db,
 	}
 }
 

--- a/consensus/dpos/dpos.go
+++ b/consensus/dpos/dpos.go
@@ -602,18 +602,18 @@ func updateMinedCnt(parentBlockTime int64, validator common.Address, dposContext
 }
 
 // getPreEpochSnapshotDelegateTrie get the snapshot delegate trie of pre epoch
-func getPreEpochSnapshotDelegateTrie(db types.DposDatabase, root common.Hash) (*trie.Trie, error) {
+func getPreEpochSnapshotDelegateTrie(db types.DposDatabase, root common.Hash) (types.DposTrie, error) {
 	return db.OpenLastDelegateTrie(root)
 }
 
-func setMinedCnt(minedCntTrie *trie.Trie, epoch int64, validator common.Address, value uint64) error {
+func setMinedCnt(minedCntTrie types.DposTrie, epoch int64, validator common.Address, value uint64) error {
 	keyBytes := makeMinedCntKey(epoch, validator)
 	valueBytes := common.Uint64ToByte(value)
 	return minedCntTrie.TryUpdate(keyBytes, valueBytes)
 }
 
 // getMinedCnt get the mined count of a specified validator in a certain epoch from the minedCntTrie
-func getMinedCnt(minedCntTrie *trie.Trie, epoch int64, validator common.Address) (uint64, error) {
+func getMinedCnt(minedCntTrie types.DposTrie, epoch int64, validator common.Address) (uint64, error) {
 	key := makeMinedCntKey(epoch, validator)
 	cntBytes, err := minedCntTrie.TryGet(key)
 	if err != nil {

--- a/consensus/dpos/dpos.go
+++ b/consensus/dpos/dpos.go
@@ -228,12 +228,12 @@ func (d *Dpos) VerifyHeaders(chain consensus.ChainReader, batch types.HeaderInse
 	go func() {
 		for i, header := range headers {
 			parents := headers[:i]
-			var validators []common.Address
-			if i != 0 {
-				validators = validatorsSet[i-1]
-			}
-			err := validateHeaderWithValidators(header)
+			err := validateHeaderWithValidators(header, validatorsSet[i])
 			if err != nil {
+				var validators []common.Address
+				if i != 0 {
+					validators = validatorsSet[i-1]
+				}
 				err = d.verifyHeader(chain, header, validators, parents, seals[i])
 			}
 			select {

--- a/consensus/dpos/dpos.go
+++ b/consensus/dpos/dpos.go
@@ -603,7 +603,7 @@ func updateMinedCnt(parentBlockTime int64, validator common.Address, dposContext
 
 // getPreEpochSnapshotDelegateTrie get the snapshot delegate trie of pre epoch
 func getPreEpochSnapshotDelegateTrie(db types.DposDatabase, root common.Hash) (*trie.Trie, error) {
-	return db.OpenEpochTrie(root)
+	return db.OpenLastDelegateTrie(root)
 }
 
 func setMinedCnt(minedCntTrie *trie.Trie, epoch int64, validator common.Address, value uint64) error {

--- a/consensus/dpos/dpos.go
+++ b/consensus/dpos/dpos.go
@@ -233,11 +233,6 @@ func (d *Dpos) VerifyHeaders(chain consensus.ChainReader, data types.HeaderInser
 				validators = validatorsSet[i-1]
 			}
 			err := d.verifyHeader(chain, header, validators, parents, seals[i])
-
-			// If validators have been changed, save the validators
-			if err == nil && (i == 0 || IsElectBlock(parents[i-1], header)) {
-				err = types.SaveValidators(validatorsSet[i], d.db)
-			}
 			select {
 			case <-abort:
 				return

--- a/consensus/dpos/dpos.go
+++ b/consensus/dpos/dpos.go
@@ -671,7 +671,6 @@ func makeMinedCntKey(epoch int64, addr common.Address) []byte {
 // and save the validators to db
 type validatorHelper interface {
 	getValidator() (common.Address, error)
-	saveValidators() error
 }
 
 // vHelper is the validatorHelper which gets info from validators
@@ -691,10 +690,6 @@ func newVHelper(validators []common.Address, header *types.Header, db ethdb.Data
 
 func (g *vHelper) getValidator() (common.Address, error) {
 	return lookupValidator(g.header.Time.Int64(), g.validators)
-}
-
-func (g *vHelper) saveValidators() error {
-	return types.SaveValidators(g.validators, g.db)
 }
 
 // dbVHelper get the validator for the header from database
@@ -733,14 +728,6 @@ func (g *dbVHelper) getValidator() (common.Address, error) {
 	}
 	g.validators = validators
 	return lookupValidator(g.header.Time.Int64(), validators)
-}
-
-func (g *dbVHelper) saveValidators() error {
-	validators, err := g.getValidators()
-	if err != nil {
-		return err
-	}
-	return types.SaveValidators(validators, g.db)
 }
 
 func (g *dbVHelper) getValidators() ([]common.Address, error) {

--- a/consensus/dpos/dpos_integration_test.go
+++ b/consensus/dpos/dpos_integration_test.go
@@ -1388,7 +1388,7 @@ func (g *genesisConfig) toBlock(db ethdb.Database) *types.Block {
 
 // dposContextWithGenesis parse the genesis to dposContext
 func dposContextWithGenesis(statedb *state.StateDB, g *genesisConfig, db ethdb.Database) (*types.DposContext, error) {
-	dc, err := types.NewDposContextFromProto(types.NewDposDb(db), &types.DposContextRoot{})
+	dc, err := types.NewDposContextFromProto(types.NewFullDposDatabase(db), &types.DposContextRoot{})
 	if err != nil {
 		return nil, err
 	}

--- a/consensus/dpos/dpos_integration_test.go
+++ b/consensus/dpos/dpos_integration_test.go
@@ -1291,7 +1291,7 @@ func forEachDelegatorForCandidate(ctx *types.DposContext, candidate common.Addre
 
 // forEachDelegatorForCandidateFromTrie iterate over the delegator votes for the candidate and execute
 //// the cb callback function
-func forEachDelegatorForCandidateFromTrie(delegateTrie *trie.Trie, candidate common.Address, cb func(delegator common.Address) error) error {
+func forEachDelegatorForCandidateFromTrie(delegateTrie types.DposTrie, candidate common.Address, cb func(delegator common.Address) error) error {
 	delegatorIterator := trie.NewIterator(delegateTrie.PrefixIterator(candidate.Bytes()))
 	var hasEntry bool
 	for delegatorIterator.Next() {

--- a/consensus/dpos/dpos_integration_test.go
+++ b/consensus/dpos/dpos_integration_test.go
@@ -1388,7 +1388,7 @@ func (g *genesisConfig) toBlock(db ethdb.Database) *types.Block {
 
 // dposContextWithGenesis parse the genesis to dposContext
 func dposContextWithGenesis(statedb *state.StateDB, g *genesisConfig, db ethdb.Database) (*types.DposContext, error) {
-	dc, err := types.NewDposContextFromProto(db, &types.DposContextRoot{})
+	dc, err := types.NewDposContextFromProto(types.NewDposDb(db), &types.DposContextRoot{})
 	if err != nil {
 		return nil, err
 	}

--- a/consensus/dpos/dpos_test.go
+++ b/consensus/dpos/dpos_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/DxChainNetwork/godx/ethdb"
 	"github.com/DxChainNetwork/godx/params"
 	"github.com/DxChainNetwork/godx/rlp"
-	"github.com/DxChainNetwork/godx/trie"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -558,7 +557,7 @@ func mockDposContext(db ethdb.Database, now int64, delegator common.Address) (*t
 	return dposContext, candidates, nil
 }
 
-func setMinedCntTrie(epochID int64, candidate common.Address, minedCntTrie *trie.Trie, count int64) error {
+func setMinedCntTrie(epochID int64, candidate common.Address, minedCntTrie types.DposTrie, count int64) error {
 	key := make([]byte, 8)
 	binary.BigEndian.PutUint64(key, uint64(epochID))
 	cntBytes := make([]byte, 8)

--- a/consensus/dpos/dpos_test.go
+++ b/consensus/dpos/dpos_test.go
@@ -142,7 +142,7 @@ func TestAccumulateRewards(t *testing.T) {
 	expectedValidatorReward := big.NewInt(1.5e+18)
 
 	// allocate the block reward among validator and its delegators
-	accumulateRewards(params.MainnetChainConfig, stateDB, header, trie.NewDatabase(db), testChain.GetHeaderByNumber(0))
+	accumulateRewards(params.MainnetChainConfig, stateDB, header, db, testChain.GetHeaderByNumber(0))
 	header.Root = stateDB.IntermediateRoot(params.MainnetChainConfig.IsEIP158(header.Number))
 
 	validatorBalance := stateDB.GetBalance(validator)
@@ -157,7 +157,7 @@ func TestAccumulateRewards(t *testing.T) {
 
 	// mock block sync
 	headerCopy := header
-	accumulateRewards(params.MainnetChainConfig, stateDbCopy, headerCopy, trie.NewDatabase(db), testChain.GetHeaderByNumber(0))
+	accumulateRewards(params.MainnetChainConfig, stateDbCopy, headerCopy, db, testChain.GetHeaderByNumber(0))
 	headerCopy.Root = stateDB.IntermediateRoot(params.MainnetChainConfig.IsEIP158(headerCopy.Number))
 
 	if header.Root != headerCopy.Root {
@@ -490,7 +490,7 @@ func (test testChainReader) insert(hash common.Hash, number uint64, time uint64,
 }
 
 func mockDposContext(db ethdb.Database, now int64, delegator common.Address) (*types.DposContext, []common.Address, error) {
-	dposContext, err := types.NewDposContextFromProto(db, &types.DposContextRoot{})
+	dposContext, err := types.NewDposContextFromProto(types.NewDposDb(db), &types.DposContextRoot{})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/consensus/dpos/dpos_test.go
+++ b/consensus/dpos/dpos_test.go
@@ -490,7 +490,7 @@ func (test testChainReader) insert(hash common.Hash, number uint64, time uint64,
 }
 
 func mockDposContext(db ethdb.Database, now int64, delegator common.Address) (*types.DposContext, []common.Address, error) {
-	dposContext, err := types.NewDposContextFromProto(types.NewDposDb(db), &types.DposContextRoot{})
+	dposContext, err := types.NewDposContextFromProto(types.NewFullDposDatabase(db), &types.DposContextRoot{})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/consensus/dpos/epoch_context.go
+++ b/consensus/dpos/epoch_context.go
@@ -226,13 +226,15 @@ func allDelegatorForValidators(ctx *types.DposContext, validators []common.Addre
 // lookupValidator returns the validator responsible for producing the block in the curTime.
 // If not a valid timestamp, an error is returned
 func (ec *EpochContext) lookupValidator(blockTime int64) (validator common.Address, err error) {
-	validator = common.Address{}
-	slot, err := calcBlockSlot(blockTime)
+	validators, err := ec.DposContext.GetValidators()
 	if err != nil {
 		return common.Address{}, err
 	}
-	// Get validators and the expected validator
-	validators, err := ec.DposContext.GetValidators()
+	return lookupValidator(blockTime, validators)
+}
+
+func lookupValidator(blockTime int64, validators []common.Address) (validator common.Address, err error) {
+	slot, err := calcBlockSlot(blockTime)
 	if err != nil {
 		return common.Address{}, err
 	}

--- a/consensus/dpos/epoch_context.go
+++ b/consensus/dpos/epoch_context.go
@@ -70,7 +70,7 @@ func (ec *EpochContext) tryElect(genesis, parent *types.Header) error {
 			return err
 		}
 		// Set the new validators
-		epochTrie, _ := ec.DposContext.DB().OpenTrie(common.Hash{})
+		epochTrie, _ := ec.DposContext.DB().OpenEpochTrie(common.Hash{})
 		ec.DposContext.SetEpoch(epochTrie)
 		err = ec.DposContext.SetValidators(validators)
 		if err != nil {

--- a/consensus/dpos/epoch_context.go
+++ b/consensus/dpos/epoch_context.go
@@ -70,7 +70,7 @@ func (ec *EpochContext) tryElect(genesis, parent *types.Header) error {
 			return err
 		}
 		// Set the new validators
-		epochTrie, _ := types.NewEpochTrie(common.Hash{}, ec.DposContext.DB())
+		epochTrie, _ := ec.DposContext.DB().OpenTrie(common.Hash{})
 		ec.DposContext.SetEpoch(epochTrie)
 		err = ec.DposContext.SetValidators(validators)
 		if err != nil {

--- a/consensus/dpos/epoch_context_test.go
+++ b/consensus/dpos/epoch_context_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestLookupValidator(t *testing.T) {
 	db := ethdb.NewMemDatabase()
-	dposCtx, _ := types.NewDposContext(db)
+	dposCtx, _ := types.NewDposContext(types.NewDposDb(db))
 	mockEpochContext := &EpochContext{
 		DposContext: dposCtx,
 	}
@@ -73,7 +73,7 @@ func Test_CountVotes(t *testing.T) {
 	stateDB, _ = state.New(root, sdb)
 
 	// create epoch context
-	dposCtx, _ := types.NewDposContext(db)
+	dposCtx, _ := types.NewDposContext(types.NewDposDb(db))
 	epochContext := &EpochContext{
 		DposContext: dposCtx,
 		stateDB:     stateDB,

--- a/consensus/dpos/epoch_context_test.go
+++ b/consensus/dpos/epoch_context_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestLookupValidator(t *testing.T) {
 	db := ethdb.NewMemDatabase()
-	dposCtx, _ := types.NewDposContext(types.NewDposDb(db))
+	dposCtx, _ := types.NewDposContext(types.NewFullDposDatabase(db))
 	mockEpochContext := &EpochContext{
 		DposContext: dposCtx,
 	}
@@ -73,7 +73,7 @@ func Test_CountVotes(t *testing.T) {
 	stateDB, _ = state.New(root, sdb)
 
 	// create epoch context
-	dposCtx, _ := types.NewDposContext(types.NewDposDb(db))
+	dposCtx, _ := types.NewDposContext(types.NewFullDposDatabase(db))
 	epochContext := &EpochContext{
 		DposContext: dposCtx,
 		stateDB:     stateDB,

--- a/consensus/dpos/epoch_context_test.go
+++ b/consensus/dpos/epoch_context_test.go
@@ -170,18 +170,27 @@ func Test_KickoutValidators(t *testing.T) {
 	}
 
 	for i := 0; i < MaxValidatorSize/3; i++ {
-		canFromTrie := epochContext.DposContext.CandidateTrie().Get(candidates[i].Bytes())
+		canFromTrie, err := epochContext.DposContext.CandidateTrie().TryGet(candidates[i].Bytes())
+		if err != nil {
+			t.Errorf("failed to get from candidate trie: %v", err)
+		}
 		if canFromTrie != nil {
 			t.Errorf("failed to delete the kick out one from candidates trie: %s", candidates[i].String())
 		}
 
-		delegatorFromTrie := epochContext.DposContext.DelegateTrie().Get(append(candidates[i].Bytes(), delegator.Bytes()...))
+		delegatorFromTrie, err := epochContext.DposContext.DelegateTrie().TryGet(append(candidates[i].Bytes(), delegator.Bytes()...))
+		if err != nil {
+			t.Errorf("failed to get from delegate trie: %v", err)
+		}
 		if delegatorFromTrie != nil {
 			t.Errorf("failed to delete the kick out one from delegate trie: %s", candidates[i].String())
 		}
 	}
 
-	votedFromTrie := epochContext.DposContext.VoteTrie().Get(delegator.Bytes())
+	votedFromTrie, err := epochContext.DposContext.VoteTrie().TryGet(delegator.Bytes())
+	if err != nil {
+		t.Errorf("failed to get from vote trie: %v", err)
+	}
 	if votedFromTrie == nil {
 		t.Fatalf("failed to retrieve voted candidates")
 	}

--- a/consensus/dpos/state_test.go
+++ b/consensus/dpos/state_test.go
@@ -36,7 +36,7 @@ func newStateAndDposContext() (*state.StateDB, *types.DposContext, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	ctx, err := types.NewDposContext(db)
+	ctx, err := types.NewDposContext(types.NewDposDb(db))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/consensus/dpos/state_test.go
+++ b/consensus/dpos/state_test.go
@@ -36,7 +36,7 @@ func newStateAndDposContext() (*state.StateDB, *types.DposContext, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	ctx, err := types.NewDposContext(types.NewDposDb(db))
+	ctx, err := types.NewDposContext(types.NewFullDposDatabase(db))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -108,8 +108,9 @@ func (ethash *Ethash) VerifyHeader(chain consensus.ChainReader, header *types.He
 // VerifyHeaders is similar to VerifyHeader, but verifies a batch of headers
 // concurrently. The method returns a quit channel to abort the operations and
 // a results channel to retrieve the async verifications.
-func (ethash *Ethash) VerifyHeaders(chain consensus.ChainReader, headers []*types.Header, validators []common.Address, seals []bool) (chan<- struct{}, <-chan error) {
+func (ethash *Ethash) VerifyHeaders(chain consensus.ChainReader, data types.HeaderInsertDataBatch, seals []bool) (chan<- struct{}, <-chan error) {
 	// If we're running a full engine faking, accept any input as valid
+	headers, _ := data.Split()
 	if ethash.config.PowMode == ModeFullFake || len(headers) == 0 {
 		abort, results := make(chan struct{}), make(chan error, len(headers))
 		for i := 0; i < len(headers); i++ {

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -108,7 +108,7 @@ func (ethash *Ethash) VerifyHeader(chain consensus.ChainReader, header *types.He
 // VerifyHeaders is similar to VerifyHeader, but verifies a batch of headers
 // concurrently. The method returns a quit channel to abort the operations and
 // a results channel to retrieve the async verifications.
-func (ethash *Ethash) VerifyHeaders(chain consensus.ChainReader, headers []*types.Header, seals []bool) (chan<- struct{}, <-chan error) {
+func (ethash *Ethash) VerifyHeaders(chain consensus.ChainReader, headers []*types.Header, validators []common.Address, seals []bool) (chan<- struct{}, <-chan error) {
 	// If we're running a full engine faking, accept any input as valid
 	if ethash.config.PowMode == ModeFullFake || len(headers) == 0 {
 		abort, results := make(chan struct{}), make(chan error, len(headers))

--- a/core/block_validator_test.go
+++ b/core/block_validator_test.go
@@ -66,7 +66,7 @@ func TestHeaderVerification(t *testing.T) {
 				_, results = engine.VerifyHeaders(chain, []*types.Header{headers[i]}, []bool{true})
 			} else {
 				engine := ethash.NewFakeFailer(headers[i].Number.Uint64())
-				_, results = engine.VerifyHeaders(chain, []*types.Header{headers[i]}, []bool{true})
+				_, results = engine.VerifyHeaders(chain, []*types.Header{headers[i]}, nil, []bool{true})
 			}
 			// Wait for the verification result
 			select {
@@ -122,7 +122,7 @@ func testHeaderConcurrentVerification(t *testing.T, threads int) {
 
 		if valid {
 			chain, _ := NewBlockChain(testdb, nil, params.DposChainConfig, dpos.NewDposFaker(), vm.Config{}, nil)
-			_, results = chain.engine.VerifyHeaders(chain, headers, seals)
+			_, results = chain.engine.VerifyHeaders(chain, headers, nil, seals)
 			chain.Stop()
 		}
 
@@ -188,7 +188,7 @@ func testHeaderConcurrentAbortion(t *testing.T, threads int) {
 	chain, _ := NewBlockChain(testdb, nil, params.DposChainConfig, dpos.NewDposFaker(), vm.Config{}, nil)
 	defer chain.Stop()
 
-	abort, results := chain.engine.VerifyHeaders(chain, headers, seals)
+	abort, results := chain.engine.VerifyHeaders(chain, headers, nil, seals)
 	close(abort)
 
 	// Deplete the results channel

--- a/core/block_validator_test.go
+++ b/core/block_validator_test.go
@@ -63,7 +63,7 @@ func TestHeaderVerification(t *testing.T) {
 
 			if valid {
 				engine := dpos.NewDposFaker()
-				_, results = engine.VerifyHeaders(chain, []*types.Header{headers[i]}, []bool{true})
+				_, results = engine.VerifyHeaders(chain, []*types.Header{headers[i]}, nil, []bool{true})
 			} else {
 				engine := ethash.NewFakeFailer(headers[i].Number.Uint64())
 				_, results = engine.VerifyHeaders(chain, []*types.Header{headers[i]}, nil, []bool{true})
@@ -122,7 +122,8 @@ func testHeaderConcurrentVerification(t *testing.T, threads int) {
 
 		if valid {
 			chain, _ := NewBlockChain(testdb, nil, params.DposChainConfig, dpos.NewDposFaker(), vm.Config{}, nil)
-			_, results = chain.engine.VerifyHeaders(chain, headers, nil, seals)
+			data := types.NewHeaderInsertDataBatch(headers, nil)
+			_, results = chain.engine.VerifyHeaders(chain, data, seals)
 			chain.Stop()
 		}
 
@@ -188,7 +189,8 @@ func testHeaderConcurrentAbortion(t *testing.T, threads int) {
 	chain, _ := NewBlockChain(testdb, nil, params.DposChainConfig, dpos.NewDposFaker(), vm.Config{}, nil)
 	defer chain.Stop()
 
-	abort, results := chain.engine.VerifyHeaders(chain, headers, nil, seals)
+	data := types.NewHeaderInsertDataBatch(headers, nil)
+	abort, results := chain.engine.VerifyHeaders(chain, data, seals)
 	close(abort)
 
 	// Deplete the results channel

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -412,7 +412,7 @@ func (bc *BlockChain) DposCtx() (*types.DposContext, error) {
 
 // DposCtxAt returns a dposCtx based on a particular point in time.
 func (bc *BlockChain) DposCtxAt(root *types.DposContextRoot) (*types.DposContext, error) {
-	return types.NewDposContextFromProto(types.NewDposDb(bc.db), root)
+	return types.NewDposContextFromProto(types.NewFullDposDatabase(bc.db), root)
 }
 
 // StateCache returns the caching database underpinning the blockchain instance.
@@ -1227,7 +1227,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 		}
 
 		// construct dpos context from parent's dpos context root
-		dposCtx, err := types.NewDposContextFromProto(types.NewDposDb(bc.db), parent.Header().DposContext)
+		dposCtx, err := types.NewDposContextFromProto(types.NewFullDposDatabase(bc.db), parent.Header().DposContext)
 		if err != nil {
 			return it.index, events, coalescedLogs, err
 		}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1656,9 +1656,9 @@ Error: %v
 // should be done or not. The reason behind the optional check is because some
 // of the header retrieval mechanisms already need to verify nonces, as well as
 // because nonces can be verified sparsely, not needing to check each.
-func (bc *BlockChain) InsertHeaderChain(chain []*types.Header, checkFreq int) (int, error) {
+func (bc *BlockChain) InsertHeaderChain(data types.HeaderInsertDataBatch, checkFreq int) (int, error) {
 	start := time.Now()
-	if i, err := bc.hc.ValidateHeaderChain(chain, checkFreq); err != nil {
+	if i, err := bc.hc.ValidateHeaderChain(data, checkFreq); err != nil {
 		return i, err
 	}
 
@@ -1669,15 +1669,18 @@ func (bc *BlockChain) InsertHeaderChain(chain []*types.Header, checkFreq int) (i
 	bc.wg.Add(1)
 	defer bc.wg.Done()
 
-	whFunc := func(header *types.Header) error {
+	whFunc := func(data types.HeaderInsertData) error {
 		bc.mu.Lock()
 		defer bc.mu.Unlock()
 
-		_, err := bc.hc.WriteHeader(header)
-		return err
+		_, err := bc.hc.WriteHeader(data.Header)
+		if err != nil {
+			return err
+		}
+		return bc.writeValidators(data.Validators)
 	}
 
-	return bc.hc.InsertHeaderChain(chain, whFunc, start)
+	return bc.hc.InsertHeaderChain(data, whFunc, start)
 }
 
 // writeHeader writes a header into the local chain, given that its parent is
@@ -1698,6 +1701,11 @@ func (bc *BlockChain) writeHeader(header *types.Header) error {
 
 	_, err := bc.hc.WriteHeader(header)
 	return err
+}
+
+// WriteValidators write validators to the underlying database
+func (bc *BlockChain) writeValidators(validators []common.Address) error {
+	return types.SaveValidators(validators, bc.db)
 }
 
 // CurrentHeader retrieves the current head header of the canonical chain. The

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -412,7 +412,7 @@ func (bc *BlockChain) DposCtx() (*types.DposContext, error) {
 
 // DposCtxAt returns a dposCtx based on a particular point in time.
 func (bc *BlockChain) DposCtxAt(root *types.DposContextRoot) (*types.DposContext, error) {
-	return types.NewDposContextFromProto(bc.db, root)
+	return types.NewDposContextFromProto(types.NewDposDb(bc.db), root)
 }
 
 // StateCache returns the caching database underpinning the blockchain instance.
@@ -1227,7 +1227,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 		}
 
 		// construct dpos context from parent's dpos context root
-		dposCtx, err := types.NewDposContextFromProto(bc.db, parent.Header().DposContext)
+		dposCtx, err := types.NewDposContextFromProto(types.NewDposDb(bc.db), parent.Header().DposContext)
 		if err != nil {
 			return it.index, events, coalescedLogs, err
 		}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1160,11 +1160,9 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 		headers[i] = block.Header()
 		seals[i] = verifySeals
 	}
-	abort, results := bc.engine.VerifyHeaders(bc, headers, nil, seals)
-	defer close(abort)
 
 	// Peek the error for the first block to decide the directing import logic
-	it := newInsertIterator(chain, results, bc.Validator())
+	it := newInsertIterator(bc, chain, bc.Validator(), bc.engine)
 
 	block, err := it.next()
 	switch {
@@ -1202,7 +1200,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 
 	// Some other error occurred, abort
 	case err != nil:
-		stats.ignored += len(it.chain)
+		stats.ignored += len(it.blocks)
 		bc.reportBlock(block, nil, err)
 		return it.index, events, coalescedLogs, err
 	}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1160,7 +1160,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 		headers[i] = block.Header()
 		seals[i] = verifySeals
 	}
-	abort, results := bc.engine.VerifyHeaders(bc, headers, seals)
+	abort, results := bc.engine.VerifyHeaders(bc, headers, nil, seals)
 	defer close(abort)
 
 	// Peek the error for the first block to decide the directing import logic

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -405,6 +405,11 @@ func (bc *BlockChain) StateAt(root common.Hash) (*state.StateDB, error) {
 	return state.New(root, bc.stateCache)
 }
 
+// DposCtx returns a new dposCtx based on the current HEAD block
+func (bc *BlockChain) DposCtx() (*types.DposContext, error) {
+	return bc.DposCtxAt(bc.CurrentHeader().DposContext)
+}
+
 // DposCtxAt returns a dposCtx based on a particular point in time.
 func (bc *BlockChain) DposCtxAt(root *types.DposContextRoot) (*types.DposContext, error) {
 	return types.NewDposContextFromProto(bc.db, root)

--- a/core/blockchain_insert.go
+++ b/core/blockchain_insert.go
@@ -19,6 +19,8 @@ package core
 import (
 	"time"
 
+	"github.com/DxChainNetwork/godx/consensus"
+
 	"github.com/DxChainNetwork/godx/common"
 	"github.com/DxChainNetwork/godx/common/mclock"
 	"github.com/DxChainNetwork/godx/core/types"
@@ -80,43 +82,45 @@ func (st *insertStats) report(chain []*types.Block, index int, cache common.Stor
 
 // insertIterator is a helper to assist during chain import.
 type insertIterator struct {
-	chain     types.Blocks
-	results   <-chan error
+	chain     consensus.ChainReader
+	blocks    types.Blocks
 	index     int
 	validator Validator
+	engine    consensus.Engine
 }
 
 // newInsertIterator creates a new iterator based on the given blocks, which are
 // assumed to be a contiguous chain.
-func newInsertIterator(chain types.Blocks, results <-chan error, validator Validator) *insertIterator {
+func newInsertIterator(chain consensus.ChainReader, blocks types.Blocks, validator Validator, engine consensus.Engine) *insertIterator {
 	return &insertIterator{
 		chain:     chain,
-		results:   results,
+		blocks:    blocks,
 		index:     -1,
 		validator: validator,
+		engine:    engine,
 	}
 }
 
 // next returns the next block in the iterator, along with any potential validation
 // error for that block. When the end is reached, it will return (nil, nil).
 func (it *insertIterator) next() (*types.Block, error) {
-	if it.index+1 >= len(it.chain) {
-		it.index = len(it.chain)
+	if it.index+1 >= len(it.blocks) {
+		it.index = len(it.blocks)
 		return nil, nil
 	}
 	it.index++
-	if err := <-it.results; err != nil {
-		return it.chain[it.index], err
+	if err := it.engine.VerifyHeader(it.chain, it.blocks[it.index].Header(), true); err != nil {
+		return it.blocks[it.index], err
 	}
-	return it.chain[it.index], it.validator.ValidateBody(it.chain[it.index])
+	return it.blocks[it.index], it.validator.ValidateBody(it.blocks[it.index])
 }
 
 // current returns the current block that's being processed.
 func (it *insertIterator) current() *types.Block {
-	if it.index < 0 || it.index+1 >= len(it.chain) {
+	if it.index < 0 || it.index+1 >= len(it.blocks) {
 		return nil
 	}
-	return it.chain[it.index]
+	return it.blocks[it.index]
 }
 
 // previous returns the previous block was being processed, or nil
@@ -124,17 +128,17 @@ func (it *insertIterator) previous() *types.Block {
 	if it.index < 1 {
 		return nil
 	}
-	return it.chain[it.index-1]
+	return it.blocks[it.index-1]
 }
 
 // first returns the first block in the it.
 func (it *insertIterator) first() *types.Block {
-	return it.chain[0]
+	return it.blocks[0]
 }
 
 // remaining returns the number of remaining blocks.
 func (it *insertIterator) remaining() int {
-	return len(it.chain) - it.index
+	return len(it.blocks) - it.index
 }
 
 // processed returns the number of processed blocks.

--- a/core/chain_indexer_test.go
+++ b/core/chain_indexer_test.go
@@ -50,7 +50,7 @@ func TestChainIndexerWithChildren(t *testing.T) {
 // are randomized.
 func testChainIndexer(t *testing.T, count int) {
 	db := ethdb.NewMemDatabase()
-	dposCtx, err := types.NewDposContext(db)
+	dposCtx, err := types.NewDposContext(types.NewDposDb(db))
 	if err != nil {
 		t.Fatalf("falied to new dpos context: %v", err)
 	}

--- a/core/chain_indexer_test.go
+++ b/core/chain_indexer_test.go
@@ -50,7 +50,7 @@ func TestChainIndexerWithChildren(t *testing.T) {
 // are randomized.
 func testChainIndexer(t *testing.T, count int) {
 	db := ethdb.NewMemDatabase()
-	dposCtx, err := types.NewDposContext(types.NewDposDb(db))
+	dposCtx, err := types.NewDposContext(types.NewFullDposDatabase(db))
 	if err != nil {
 		t.Fatalf("falied to new dpos context: %v", err)
 	}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -441,7 +441,7 @@ func decodePrealloc(data string) GenesisAlloc {
 
 // initGenesisDposContext returns the dpos context of given genesis block
 func initGenesisDposContext(stateDB *state.StateDB, g *Genesis, db ethdb.Database) (*types.DposContext, error) {
-	dc, err := types.NewDposContextFromProto(types.NewDposDb(db), &types.DposContextRoot{})
+	dc, err := types.NewDposContextFromProto(types.NewFullDposDatabase(db), &types.DposContextRoot{})
 	if err != nil {
 		return nil, err
 	}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -441,7 +441,7 @@ func decodePrealloc(data string) GenesisAlloc {
 
 // initGenesisDposContext returns the dpos context of given genesis block
 func initGenesisDposContext(stateDB *state.StateDB, g *Genesis, db ethdb.Database) (*types.DposContext, error) {
-	dc, err := types.NewDposContextFromProto(db, &types.DposContextRoot{})
+	dc, err := types.NewDposContextFromProto(types.NewDposDb(db), &types.DposContextRoot{})
 	if err != nil {
 		return nil, err
 	}

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -41,7 +41,7 @@ func TestDefaultGenesisBlock(t *testing.T) {
 
 func TestSetupGenesis(t *testing.T) {
 	var (
-		customghash = common.HexToHash("0x796c3d4be7f1958e8dff2428b4c21b277ca890c606b1fdc4f43e950154ed7eff")
+		customghash = common.HexToHash("0xbfcc983a9994ac4aab200b4e7db90ac26842ee059d60c83462dd7a9a3cce10fc")
 		customg     = Genesis{
 			Config: params.DposChainConfig,
 			Alloc: MakeAlloc(

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -228,7 +228,8 @@ func (hc *HeaderChain) ValidateHeaderChain(chain []*types.Header, checkFreq int)
 	}
 	seals[len(seals)-1] = true // Last should always be verified to avoid junk
 
-	abort, results := hc.engine.VerifyHeaders(hc, chain, nil, seals)
+	data := types.NewHeaderInsertDataBatch(chain, nil)
+	abort, results := hc.engine.VerifyHeaders(hc, data, seals)
 	defer close(abort)
 
 	// Iterate over the headers and ensure they all check out

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -228,7 +228,7 @@ func (hc *HeaderChain) ValidateHeaderChain(chain []*types.Header, checkFreq int)
 	}
 	seals[len(seals)-1] = true // Last should always be verified to avoid junk
 
-	abort, results := hc.engine.VerifyHeaders(hc, chain, seals)
+	abort, results := hc.engine.VerifyHeaders(hc, chain, nil, seals)
 	defer close(abort)
 
 	// Iterate over the headers and ensure they all check out

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -197,14 +197,20 @@ func (hc *HeaderChain) WriteHeader(header *types.Header) (status WriteStatus, er
 	return
 }
 
+// WriteValidators write validators to the underlying database
+func (hc *HeaderChain) WriteValidators(validators []common.Address) error {
+	return types.SaveValidators(validators, hc.chainDb)
+}
+
 // WhCallback is a callback function for inserting individual headers.
 // A callback is used for two reasons: first, in a LightChain, status should be
 // processed and light chain events sent, while in a BlockChain this is not
 // necessary since chain events are sent after inserting blocks. Second, the
 // header writes should be protected by the parent chain mutex individually.
-type WhCallback func(*types.Header) error
+type WhCallback func(data types.HeaderInsertData) error
 
-func (hc *HeaderChain) ValidateHeaderChain(chain []*types.Header, checkFreq int) (int, error) {
+func (hc *HeaderChain) ValidateHeaderChain(data types.HeaderInsertDataBatch, checkFreq int) (int, error) {
+	chain, _ := data.Split()
 	// Do a sanity check that the provided chain is actually ordered and linked
 	for i := 1; i < len(chain); i++ {
 		if chain[i].Number.Uint64() != chain[i-1].Number.Uint64()+1 || chain[i].ParentHash != chain[i-1].Hash() {
@@ -228,7 +234,6 @@ func (hc *HeaderChain) ValidateHeaderChain(chain []*types.Header, checkFreq int)
 	}
 	seals[len(seals)-1] = true // Last should always be verified to avoid junk
 
-	data := types.NewHeaderInsertDataBatch(chain, nil)
 	abort, results := hc.engine.VerifyHeaders(hc, data, seals)
 	defer close(abort)
 
@@ -260,27 +265,28 @@ func (hc *HeaderChain) ValidateHeaderChain(chain []*types.Header, checkFreq int)
 // should be done or not. The reason behind the optional check is because some
 // of the header retrieval mechanisms already need to verfy nonces, as well as
 // because nonces can be verified sparsely, not needing to check each.
-func (hc *HeaderChain) InsertHeaderChain(chain []*types.Header, writeHeader WhCallback, start time.Time) (int, error) {
+func (hc *HeaderChain) InsertHeaderChain(dataBatch types.HeaderInsertDataBatch, writeData WhCallback, start time.Time) (int, error) {
 	// Collect some import statistics to report on
 	stats := struct{ processed, ignored int }{}
 	// All headers passed verification, import them into the database
-	for i, header := range chain {
+	for i, data := range dataBatch {
 		// Short circuit insertion if shutting down
 		if hc.procInterrupt() {
 			log.Debug("Premature abort during headers import")
 			return i, errors.New("aborted")
 		}
 		// If the header's already known, skip it, otherwise store
-		if hc.HasHeader(header.Hash(), header.Number.Uint64()) {
+		if hc.HasHeader(data.Header.Hash(), data.Header.Number.Uint64()) {
 			stats.ignored++
 			continue
 		}
-		if err := writeHeader(header); err != nil {
+		if err := writeData(data); err != nil {
 			return i, err
 		}
 		stats.processed++
 	}
 	// Report some public statistics so the user has a clue what's going on
+	chain, _ := dataBatch.Split()
 	last := chain[len(chain)-1]
 
 	context := []interface{}{

--- a/core/rawdb/accessors_branch_test.go
+++ b/core/rawdb/accessors_branch_test.go
@@ -23,7 +23,7 @@ func TestFindCommonAncestor(t *testing.T) {
 	//					^|
 	//				header03
 
-	dposCtx, err := types.NewDposContext(types.NewDposDb(db))
+	dposCtx, err := types.NewDposContext(types.NewFullDposDatabase(db))
 	if err != nil {
 		t.Fatalf("failed to new dpos context: %v", err)
 	}

--- a/core/rawdb/accessors_branch_test.go
+++ b/core/rawdb/accessors_branch_test.go
@@ -23,7 +23,7 @@ func TestFindCommonAncestor(t *testing.T) {
 	//					^|
 	//				header03
 
-	dposCtx, err := types.NewDposContext(db)
+	dposCtx, err := types.NewDposContext(types.NewDposDb(db))
 	if err != nil {
 		t.Fatalf("failed to new dpos context: %v", err)
 	}

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -27,7 +27,7 @@ import (
 // Tests block header storage and retrieval operations.
 func TestHeaderStorage(t *testing.T) {
 	db := ethdb.NewMemDatabase()
-	dposCtx, err := types.NewDposContext(db)
+	dposCtx, err := types.NewDposContext(types.NewDposDb(db))
 	if err != nil {
 		t.Fatalf("failed to new dpos context: %v", err)
 	}
@@ -64,7 +64,7 @@ func TestHeaderStorage(t *testing.T) {
 // Tests block body storage and retrieval operations.
 func TestBodyStorage(t *testing.T) {
 	db := ethdb.NewMemDatabase()
-	dposCtx, err := types.NewDposContext(db)
+	dposCtx, err := types.NewDposContext(types.NewDposDb(db))
 	if err != nil {
 		t.Fatalf("failed to new dpos context: %v", err)
 	}

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -27,7 +27,7 @@ import (
 // Tests block header storage and retrieval operations.
 func TestHeaderStorage(t *testing.T) {
 	db := ethdb.NewMemDatabase()
-	dposCtx, err := types.NewDposContext(types.NewDposDb(db))
+	dposCtx, err := types.NewDposContext(types.NewFullDposDatabase(db))
 	if err != nil {
 		t.Fatalf("failed to new dpos context: %v", err)
 	}
@@ -64,7 +64,7 @@ func TestHeaderStorage(t *testing.T) {
 // Tests block body storage and retrieval operations.
 func TestBodyStorage(t *testing.T) {
 	db := ethdb.NewMemDatabase()
-	dposCtx, err := types.NewDposContext(types.NewDposDb(db))
+	dposCtx, err := types.NewDposContext(types.NewFullDposDatabase(db))
 	if err != nil {
 		t.Fatalf("failed to new dpos context: %v", err)
 	}

--- a/core/types/dpos_context.go
+++ b/core/types/dpos_context.go
@@ -31,32 +31,27 @@ type DposContext struct {
 }
 
 var (
-	epochPrefix     = []byte("epoch-")
-	delegatePrefix  = []byte("delegate-")
-	votePrefix      = []byte("vote-")
-	candidatePrefix = []byte("candidate-")
-	minedCntPrefix  = []byte("minedCnt-")
-	keyValidator    = []byte("validator")
+	keyValidator = []byte("validator")
 )
 
 func NewEpochTrie(root common.Hash, db *trie.Database) (*trie.Trie, error) {
-	return trie.NewTrieWithPrefix(root, epochPrefix, db)
+	return trie.New(root, db)
 }
 
 func NewDelegateTrie(root common.Hash, db *trie.Database) (*trie.Trie, error) {
-	return trie.NewTrieWithPrefix(root, delegatePrefix, db)
+	return trie.New(root, db)
 }
 
 func NewVoteTrie(root common.Hash, db *trie.Database) (*trie.Trie, error) {
-	return trie.NewTrieWithPrefix(root, votePrefix, db)
+	return trie.New(root, db)
 }
 
 func NewCandidateTrie(root common.Hash, db *trie.Database) (*trie.Trie, error) {
-	return trie.NewTrieWithPrefix(root, candidatePrefix, db)
+	return trie.New(root, db)
 }
 
 func NewMinedCntTrie(root common.Hash, db *trie.Database) (*trie.Trie, error) {
-	return trie.NewTrieWithPrefix(root, minedCntPrefix, db)
+	return trie.New(root, db)
 }
 
 // NewDposContext creates DposContext with the given database

--- a/core/types/dpos_context.go
+++ b/core/types/dpos_context.go
@@ -550,10 +550,18 @@ func (dc *DposContext) SetMinedCnt(minedCnt DposTrie)   { dc.minedCntTrie = mine
 
 // GetValidators retrieves validator list in current epoch
 func (dc *DposContext) GetValidators() ([]common.Address, error) {
+	return GetValidatorsFromDposTrie(dc.epochTrie)
+}
+
+// GetValidatorsFromDposTrie get the list of validators from the trie
+func GetValidatorsFromDposTrie(t DposTrie) ([]common.Address, error) {
 	var validators []common.Address
-	validatorsRLP, err := dc.epochTrie.TryGet(keyValidator)
+	validatorsRLP, err := t.TryGet(keyValidator)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get validator: %v", err)
+	}
+	if len(validatorsRLP) == 0 {
+		return nil, fmt.Errorf("empty value for validators, make sure opening the epoch trie")
 	}
 	if err := rlp.DecodeBytes(validatorsRLP, &validators); err != nil {
 		return nil, fmt.Errorf("failed to decode validators: %s", err)

--- a/core/types/dpos_context.go
+++ b/core/types/dpos_context.go
@@ -38,8 +38,8 @@ var (
 // Implemented by both FullDposDatabase and light.DposDatabase
 type DposDatabase interface {
 	OpenEpochTrie(root common.Hash) (*trie.Trie, error)
-	OpenLastEpochTrie(root common.Hash) (*trie.Trie, error)
 	OpenDelegateTrie(root common.Hash) (*trie.Trie, error)
+	OpenLastDelegateTrie(root common.Hash) (*trie.Trie, error)
 	OpenVoteTrie(root common.Hash) (*trie.Trie, error)
 	OpenCandidateTrie(root common.Hash) (*trie.Trie, error)
 	OpenMinedCntTrie(root common.Hash) (*trie.Trie, error)
@@ -61,13 +61,13 @@ func (db *FullDposDatabase) OpenEpochTrie(root common.Hash) (*trie.Trie, error) 
 	return db.openTrie(root)
 }
 
-// OpenLastEpochTrie opens the epochTrie in the last epoch
-func (db *FullDposDatabase) OpenLastEpochTrie(root common.Hash) (*trie.Trie, error) {
+// OpenDelegateTrie opens the delegateTrie
+func (db *FullDposDatabase) OpenDelegateTrie(root common.Hash) (*trie.Trie, error) {
 	return db.openTrie(root)
 }
 
-// OpenDelegateTrie opens the delegateTrie
-func (db *FullDposDatabase) OpenDelegateTrie(root common.Hash) (*trie.Trie, error) {
+// OpenLastEpochTrie opens the epochTrie in the last epoch
+func (db *FullDposDatabase) OpenLastDelegateTrie(root common.Hash) (*trie.Trie, error) {
 	return db.openTrie(root)
 }
 

--- a/core/types/dpos_context.go
+++ b/core/types/dpos_context.go
@@ -200,15 +200,26 @@ func (dc *DposContext) ToRoot() *DposContextRoot {
 }
 
 // Root calculates the root hash of 5 tries in DposContext
-func (dcp *DposContextRoot) Root() (h common.Hash) {
+func (dcr *DposContextRoot) Root() (h common.Hash) {
 	hw := sha3.NewLegacyKeccak256()
-	rlp.Encode(hw, dcp.EpochRoot)
-	rlp.Encode(hw, dcp.DelegateRoot)
-	rlp.Encode(hw, dcp.CandidateRoot)
-	rlp.Encode(hw, dcp.VoteRoot)
-	rlp.Encode(hw, dcp.MinedCntRoot)
+	rlp.Encode(hw, dcr.EpochRoot)
+	rlp.Encode(hw, dcr.DelegateRoot)
+	rlp.Encode(hw, dcr.CandidateRoot)
+	rlp.Encode(hw, dcr.VoteRoot)
+	rlp.Encode(hw, dcr.MinedCntRoot)
 	hw.Sum(h[:0])
 	return h
+}
+
+// Copy makes a copy of the DposContextRoot
+func (dcr *DposContextRoot) Copy() *DposContextRoot {
+	return &DposContextRoot{
+		EpochRoot:     dcr.EpochRoot,
+		DelegateRoot:  dcr.DelegateRoot,
+		CandidateRoot: dcr.CandidateRoot,
+		VoteRoot:      dcr.VoteRoot,
+		MinedCntRoot:  dcr.MinedCntRoot,
+	}
 }
 
 // KickoutCandidate will kick out the given candidate

--- a/core/types/dpos_context.go
+++ b/core/types/dpos_context.go
@@ -35,9 +35,14 @@ var (
 )
 
 // DposDatabase is the underlying database under the dposCtx.
-// Implemented by both FullDposDatabase and light.OdrDposDatabase
+// Implemented by both FullDposDatabase and light.DposDatabase
 type DposDatabase interface {
-	OpenTrie(root common.Hash) (*trie.Trie, error)
+	OpenEpochTrie(root common.Hash) (*trie.Trie, error)
+	OpenLastEpochTrie(root common.Hash) (*trie.Trie, error)
+	OpenDelegateTrie(root common.Hash) (*trie.Trie, error)
+	OpenVoteTrie(root common.Hash) (*trie.Trie, error)
+	OpenCandidateTrie(root common.Hash) (*trie.Trie, error)
+	OpenMinedCntTrie(root common.Hash) (*trie.Trie, error)
 }
 
 // FullDposDatabase is the database for full node's dpos contents
@@ -45,40 +50,69 @@ type FullDposDatabase struct {
 	db *trie.Database
 }
 
-// NewDposDb creates a new FullDposDatabase based on a diskdb
-func NewDposDb(diskdb ethdb.Database) *FullDposDatabase {
+// NewFullDposDatabase creates a new FullDposDatabase based on a diskdb
+func NewFullDposDatabase(diskdb ethdb.Database) *FullDposDatabase {
 	tdb := trie.NewDatabase(diskdb)
 	return &FullDposDatabase{tdb}
 }
 
-// OpenTrie opens a trie with the given root
-func (db *FullDposDatabase) OpenTrie(root common.Hash) (*trie.Trie, error) {
+// OpenEpochTrie opens the epochTrie
+func (db *FullDposDatabase) OpenEpochTrie(root common.Hash) (*trie.Trie, error) {
+	return db.openTrie(root)
+}
+
+// OpenLastEpochTrie opens the epochTrie in the last epoch
+func (db *FullDposDatabase) OpenLastEpochTrie(root common.Hash) (*trie.Trie, error) {
+	return db.openTrie(root)
+}
+
+// OpenDelegateTrie opens the delegateTrie
+func (db *FullDposDatabase) OpenDelegateTrie(root common.Hash) (*trie.Trie, error) {
+	return db.openTrie(root)
+}
+
+// OpenVoteTrie opens the voteTrie
+func (db *FullDposDatabase) OpenVoteTrie(root common.Hash) (*trie.Trie, error) {
+	return db.openTrie(root)
+}
+
+// OpenCandidateTrie opens the CandidateTrie
+func (db *FullDposDatabase) OpenCandidateTrie(root common.Hash) (*trie.Trie, error) {
+	return db.openTrie(root)
+}
+
+// OpenMinedCntTrie opens the MinedCntTrie
+func (db *FullDposDatabase) OpenMinedCntTrie(root common.Hash) (*trie.Trie, error) {
+	return db.openTrie(root)
+}
+
+func (db *FullDposDatabase) openTrie(root common.Hash) (*trie.Trie, error) {
 	return trie.New(root, db.db)
 }
 
 // NewDposContext creates DposContext with the given database
 func NewDposContext(db DposDatabase) (*DposContext, error) {
-	epochTrie, err := db.OpenTrie(common.Hash{})
+	epochTrie, err := db.OpenEpochTrie(common.Hash{})
 	if err != nil {
 		return nil, err
 	}
 
-	delegateTrie, err := db.OpenTrie(common.Hash{})
+	delegateTrie, err := db.OpenDelegateTrie(common.Hash{})
 	if err != nil {
 		return nil, err
 	}
 
-	voteTrie, err := db.OpenTrie(common.Hash{})
+	voteTrie, err := db.OpenVoteTrie(common.Hash{})
 	if err != nil {
 		return nil, err
 	}
 
-	candidateTrie, err := db.OpenTrie(common.Hash{})
+	candidateTrie, err := db.OpenCandidateTrie(common.Hash{})
 	if err != nil {
 		return nil, err
 	}
 
-	minedCntTrie, err := db.OpenTrie(common.Hash{})
+	minedCntTrie, err := db.OpenMinedCntTrie(common.Hash{})
 	if err != nil {
 		return nil, err
 	}
@@ -95,27 +129,27 @@ func NewDposContext(db DposDatabase) (*DposContext, error) {
 
 // NewDposContextFromProto creates DposContext with database and trie root
 func NewDposContextFromProto(db DposDatabase, ctxProto *DposContextRoot) (*DposContext, error) {
-	epochTrie, err := db.OpenTrie(ctxProto.EpochRoot)
+	epochTrie, err := db.OpenEpochTrie(ctxProto.EpochRoot)
 	if err != nil {
 		return nil, err
 	}
 
-	delegateTrie, err := db.OpenTrie(ctxProto.DelegateRoot)
+	delegateTrie, err := db.OpenDelegateTrie(ctxProto.DelegateRoot)
 	if err != nil {
 		return nil, err
 	}
 
-	voteTrie, err := db.OpenTrie(ctxProto.VoteRoot)
+	voteTrie, err := db.OpenVoteTrie(ctxProto.VoteRoot)
 	if err != nil {
 		return nil, err
 	}
 
-	candidateTrie, err := db.OpenTrie(ctxProto.CandidateRoot)
+	candidateTrie, err := db.OpenCandidateTrie(ctxProto.CandidateRoot)
 	if err != nil {
 		return nil, err
 	}
 
-	minedCntTrie, err := db.OpenTrie(ctxProto.MinedCntRoot)
+	minedCntTrie, err := db.OpenMinedCntTrie(ctxProto.MinedCntRoot)
 	if err != nil {
 		return nil, err
 	}

--- a/core/types/dpos_context_test.go
+++ b/core/types/dpos_context_test.go
@@ -128,13 +128,13 @@ func TestDposContextVoteAndCancelVote(t *testing.T) {
 	assert.Nil(t, err)
 	delegateIter := trie.NewIterator(dposContext.delegateTrie.PrefixIterator(candidate.Bytes()))
 	if assert.True(t, delegateIter.Next()) {
-		assert.Equal(t, append(delegatePrefix, append(candidate.Bytes(), delegator.Bytes()...)...), delegateIter.Key)
+		assert.Equal(t, append(candidate.Bytes(), delegator.Bytes()...), delegateIter.Key)
 		assert.Equal(t, delegator, common.BytesToAddress(delegateIter.Value))
 	}
 
 	voteIter := trie.NewIterator(dposContext.voteTrie.NodeIterator(nil))
 	if assert.True(t, voteIter.Next()) {
-		assert.Equal(t, append(votePrefix, delegator.Bytes()...), voteIter.Key)
+		assert.Equal(t, delegator.Bytes(), voteIter.Key)
 		assert.Equal(t, candidate, common.BytesToAddress(voteIter.Value))
 	}
 
@@ -145,13 +145,13 @@ func TestDposContextVoteAndCancelVote(t *testing.T) {
 	assert.False(t, delegateIter.Next())
 	delegateIter = trie.NewIterator(dposContext.delegateTrie.PrefixIterator(newCandidate.Bytes()))
 	if assert.True(t, delegateIter.Next()) {
-		assert.Equal(t, append(delegatePrefix, append(newCandidate.Bytes(), delegator.Bytes()...)...), delegateIter.Key)
+		assert.Equal(t, append(newCandidate.Bytes(), delegator.Bytes()...), delegateIter.Key)
 		assert.Equal(t, delegator, common.BytesToAddress(delegateIter.Value))
 	}
 
 	voteIter = trie.NewIterator(dposContext.voteTrie.NodeIterator(nil))
 	if assert.True(t, voteIter.Next()) {
-		assert.Equal(t, append(votePrefix, delegator.Bytes()...), voteIter.Key)
+		assert.Equal(t, delegator.Bytes(), voteIter.Key)
 		assert.Equal(t, newCandidate, common.BytesToAddress(voteIter.Value))
 	}
 

--- a/core/types/dpos_context_test.go
+++ b/core/types/dpos_context_test.go
@@ -26,7 +26,7 @@ var (
 
 func TestDposContextSnapshot(t *testing.T) {
 	db := ethdb.NewMemDatabase()
-	dposContext, err := NewDposContext(db)
+	dposContext, err := NewDposContext(NewDposDb(db))
 	assert.Nil(t, err)
 
 	snapshot := dposContext.Snapshot()
@@ -46,7 +46,7 @@ func TestDposContextSnapshot(t *testing.T) {
 func TestDposContextBecomeCandidate(t *testing.T) {
 	candidates := addresses
 	db := ethdb.NewMemDatabase()
-	dposContext, err := NewDposContext(db)
+	dposContext, err := NewDposContext(NewDposDb(db))
 	assert.Nil(t, err)
 	for _, candidate := range candidates {
 		assert.Nil(t, dposContext.BecomeCandidate(candidate))
@@ -67,7 +67,7 @@ func TestDposContextBecomeCandidate(t *testing.T) {
 func TestDposContextKickoutCandidate(t *testing.T) {
 	candidates := addresses
 	db := ethdb.NewMemDatabase()
-	dposContext, err := NewDposContext(db)
+	dposContext, err := NewDposContext(NewDposDb(db))
 	assert.Nil(t, err)
 	for _, candidate := range candidates {
 		assert.Nil(t, dposContext.BecomeCandidate(candidate))
@@ -108,7 +108,7 @@ func TestDposContextVoteAndCancelVote(t *testing.T) {
 	newCandidate := addresses[1]
 	delegator := addresses[2]
 	db := ethdb.NewMemDatabase()
-	dposContext, err := NewDposContext(db)
+	dposContext, err := NewDposContext(NewDposDb(db))
 	assert.Nil(t, err)
 	assert.Nil(t, dposContext.BecomeCandidate(candidate))
 	assert.Nil(t, dposContext.BecomeCandidate(newCandidate))
@@ -169,7 +169,7 @@ func TestDposContextVoteAndCancelVote(t *testing.T) {
 func TestDposContextValidators(t *testing.T) {
 	validators := addresses
 	db := ethdb.NewMemDatabase()
-	dposContext, err := NewDposContext(db)
+	dposContext, err := NewDposContext(NewDposDb(db))
 
 	assert.Nil(t, err)
 	assert.Nil(t, dposContext.SetValidators(validators))
@@ -190,7 +190,7 @@ func TestDposContextValidators(t *testing.T) {
 
 func TestDposContext_GetVotedCandidatesByAddress(t *testing.T) {
 	db := ethdb.NewMemDatabase()
-	dposContext, err := NewDposContext(db)
+	dposContext, err := NewDposContext(NewDposDb(db))
 	assert.Nil(t, err)
 
 	bytes, err := rlp.EncodeToBytes(addresses)

--- a/core/types/dpos_context_test.go
+++ b/core/types/dpos_context_test.go
@@ -26,7 +26,7 @@ var (
 
 func TestDposContextSnapshot(t *testing.T) {
 	db := ethdb.NewMemDatabase()
-	dposContext, err := NewDposContext(NewDposDb(db))
+	dposContext, err := NewDposContext(NewFullDposDatabase(db))
 	assert.Nil(t, err)
 
 	snapshot := dposContext.Snapshot()
@@ -46,7 +46,7 @@ func TestDposContextSnapshot(t *testing.T) {
 func TestDposContextBecomeCandidate(t *testing.T) {
 	candidates := addresses
 	db := ethdb.NewMemDatabase()
-	dposContext, err := NewDposContext(NewDposDb(db))
+	dposContext, err := NewDposContext(NewFullDposDatabase(db))
 	assert.Nil(t, err)
 	for _, candidate := range candidates {
 		assert.Nil(t, dposContext.BecomeCandidate(candidate))
@@ -67,7 +67,7 @@ func TestDposContextBecomeCandidate(t *testing.T) {
 func TestDposContextKickoutCandidate(t *testing.T) {
 	candidates := addresses
 	db := ethdb.NewMemDatabase()
-	dposContext, err := NewDposContext(NewDposDb(db))
+	dposContext, err := NewDposContext(NewFullDposDatabase(db))
 	assert.Nil(t, err)
 	for _, candidate := range candidates {
 		assert.Nil(t, dposContext.BecomeCandidate(candidate))
@@ -108,7 +108,7 @@ func TestDposContextVoteAndCancelVote(t *testing.T) {
 	newCandidate := addresses[1]
 	delegator := addresses[2]
 	db := ethdb.NewMemDatabase()
-	dposContext, err := NewDposContext(NewDposDb(db))
+	dposContext, err := NewDposContext(NewFullDposDatabase(db))
 	assert.Nil(t, err)
 	assert.Nil(t, dposContext.BecomeCandidate(candidate))
 	assert.Nil(t, dposContext.BecomeCandidate(newCandidate))
@@ -169,7 +169,7 @@ func TestDposContextVoteAndCancelVote(t *testing.T) {
 func TestDposContextValidators(t *testing.T) {
 	validators := addresses
 	db := ethdb.NewMemDatabase()
-	dposContext, err := NewDposContext(NewDposDb(db))
+	dposContext, err := NewDposContext(NewFullDposDatabase(db))
 
 	assert.Nil(t, err)
 	assert.Nil(t, dposContext.SetValidators(validators))
@@ -190,7 +190,7 @@ func TestDposContextValidators(t *testing.T) {
 
 func TestDposContext_GetVotedCandidatesByAddress(t *testing.T) {
 	db := ethdb.NewMemDatabase()
-	dposContext, err := NewDposContext(NewDposDb(db))
+	dposContext, err := NewDposContext(NewFullDposDatabase(db))
 	assert.Nil(t, err)
 
 	bytes, err := rlp.EncodeToBytes(addresses)

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -169,7 +169,7 @@ type LightChain interface {
 	GetTd(common.Hash, uint64) *big.Int
 
 	// InsertHeaderChain inserts a batch of headers into the local chain.
-	InsertHeaderChain([]*types.Header, int) (int, error)
+	InsertHeaderChain(types.HeaderInsertDataBatch, int) (int, error)
 
 	// Rollback removes a few recently added elements from the local chain.
 	Rollback([]common.Hash)

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -200,9 +200,11 @@ func (dl *downloadTester) GetTd(hash common.Hash, number uint64) *big.Int {
 }
 
 // InsertHeaderChain injects a new batch of headers into the simulated chain.
-func (dl *downloadTester) InsertHeaderChain(headers []*types.Header, checkFreq int) (i int, err error) {
+func (dl *downloadTester) InsertHeaderChain(data types.HeaderInsertDataBatch, checkFreq int) (i int, err error) {
 	dl.lock.Lock()
 	defer dl.lock.Unlock()
+
+	headers, _ := data.Split()
 
 	// Do a quick check, as the blockchain.InsertHeaderChain doesn't insert anything in case of errors
 	if _, ok := dl.ownHeaders[headers[0].ParentHash]; !ok {

--- a/eth/dpos_api.go
+++ b/eth/dpos_api.go
@@ -12,7 +12,6 @@ import (
 	"github.com/DxChainNetwork/godx/consensus/dpos"
 	"github.com/DxChainNetwork/godx/core/types"
 	"github.com/DxChainNetwork/godx/rpc"
-	"github.com/DxChainNetwork/godx/trie"
 )
 
 // PublicDposAPI object is used to implement all
@@ -123,8 +122,8 @@ func (d *PublicDposAPI) Candidate(candidateAddress common.Address, blockNr *rpc.
 	}
 
 	// get detailed information
-	trieDb := trie.NewDatabase(d.e.ChainDb())
-	candidateDeposit, candidateVotes, rewardRatio, err := dpos.GetCandidateInfo(statedb, candidateAddress, header, trieDb)
+	diskdb := d.e.ChainDb()
+	candidateDeposit, candidateVotes, rewardRatio, err := dpos.GetCandidateInfo(statedb, candidateAddress, header, diskdb)
 	if err != nil {
 		return CandidateInfo{}, err
 	}

--- a/les/distributor_test.go
+++ b/les/distributor_test.go
@@ -1,0 +1,185 @@
+// Copyright 2017 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// Package light implements on-demand retrieval capable state and chain objects
+// for the Ethereum Light Client.
+package les
+
+import (
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+)
+
+type testDistReq struct {
+	cost, procTime, order uint64
+	canSendTo             map[*testDistPeer]struct{}
+}
+
+func (r *testDistReq) getCost(dp distPeer) uint64 {
+	return r.cost
+}
+
+func (r *testDistReq) canSend(dp distPeer) bool {
+	_, ok := r.canSendTo[dp.(*testDistPeer)]
+	return ok
+}
+
+func (r *testDistReq) request(dp distPeer) func() {
+	return func() { dp.(*testDistPeer).send(r) }
+}
+
+type testDistPeer struct {
+	sent    []*testDistReq
+	sumCost uint64
+	lock    sync.RWMutex
+}
+
+func (p *testDistPeer) send(r *testDistReq) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.sent = append(p.sent, r)
+	p.sumCost += r.cost
+}
+
+func (p *testDistPeer) worker(t *testing.T, checkOrder bool, stop chan struct{}) {
+	var last uint64
+	for {
+		wait := time.Millisecond
+		p.lock.Lock()
+		if len(p.sent) > 0 {
+			rq := p.sent[0]
+			wait = time.Duration(rq.procTime)
+			p.sumCost -= rq.cost
+			if checkOrder {
+				if rq.order <= last {
+					t.Errorf("Requests processed in wrong order")
+				}
+				last = rq.order
+			}
+			p.sent = p.sent[1:]
+		}
+		p.lock.Unlock()
+		select {
+		case <-stop:
+			return
+		case <-time.After(wait):
+		}
+	}
+}
+
+const (
+	testDistBufLimit       = 10000000
+	testDistMaxCost        = 1000000
+	testDistPeerCount      = 5
+	testDistReqCount       = 5000
+	testDistMaxResendCount = 3
+)
+
+func (p *testDistPeer) waitBefore(cost uint64) (time.Duration, float64) {
+	p.lock.RLock()
+	sumCost := p.sumCost + cost
+	p.lock.RUnlock()
+	if sumCost < testDistBufLimit {
+		return 0, float64(testDistBufLimit-sumCost) / float64(testDistBufLimit)
+	}
+	return time.Duration(sumCost - testDistBufLimit), 0
+}
+
+func (p *testDistPeer) canQueue() bool {
+	return true
+}
+
+func (p *testDistPeer) queueSend(f func()) {
+	f()
+}
+
+func TestRequestDistributor(t *testing.T) {
+	testRequestDistributor(t, false)
+}
+
+func TestRequestDistributorResend(t *testing.T) {
+	testRequestDistributor(t, true)
+}
+
+func testRequestDistributor(t *testing.T, resend bool) {
+	stop := make(chan struct{})
+	defer close(stop)
+
+	dist := newRequestDistributor(nil, stop)
+	var peers [testDistPeerCount]*testDistPeer
+	for i := range peers {
+		peers[i] = &testDistPeer{}
+		go peers[i].worker(t, !resend, stop)
+		dist.registerTestPeer(peers[i])
+	}
+
+	var wg sync.WaitGroup
+
+	for i := 1; i <= testDistReqCount; i++ {
+		cost := uint64(rand.Int63n(testDistMaxCost))
+		procTime := uint64(rand.Int63n(int64(cost + 1)))
+		rq := &testDistReq{
+			cost:      cost,
+			procTime:  procTime,
+			order:     uint64(i),
+			canSendTo: make(map[*testDistPeer]struct{}),
+		}
+		for _, peer := range peers {
+			if rand.Intn(2) != 0 {
+				rq.canSendTo[peer] = struct{}{}
+			}
+		}
+
+		wg.Add(1)
+		req := &distReq{
+			getCost: rq.getCost,
+			canSend: rq.canSend,
+			request: rq.request,
+		}
+		chn := dist.queue(req)
+		go func() {
+			cnt := 1
+			if resend && len(rq.canSendTo) != 0 {
+				cnt = rand.Intn(testDistMaxResendCount) + 1
+			}
+			for i := 0; i < cnt; i++ {
+				if i != 0 {
+					chn = dist.queue(req)
+				}
+				p := <-chn
+				if p == nil {
+					if len(rq.canSendTo) != 0 {
+						t.Errorf("Request that could have been sent was dropped")
+					}
+				} else {
+					peer := p.(*testDistPeer)
+					if _, ok := rq.canSendTo[peer]; !ok {
+						t.Errorf("Request sent to wrong peer")
+					}
+				}
+			}
+			wg.Done()
+		}()
+		if rand.Intn(1000) == 0 {
+			time.Sleep(time.Duration(rand.Intn(5000000)))
+		}
+	}
+
+	wg.Wait()
+}

--- a/les/execqueue_test.go
+++ b/les/execqueue_test.go
@@ -1,0 +1,62 @@
+// Copyright 2017 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package les
+
+import (
+	"testing"
+)
+
+func TestExecQueue(t *testing.T) {
+	var (
+		N        = 10000
+		q        = newExecQueue(N)
+		counter  int
+		execd    = make(chan int)
+		testexit = make(chan struct{})
+	)
+	defer q.quit()
+	defer close(testexit)
+
+	check := func(state string, wantOK bool) {
+		c := counter
+		counter++
+		qf := func() {
+			select {
+			case execd <- c:
+			case <-testexit:
+			}
+		}
+		if q.canQueue() != wantOK {
+			t.Fatalf("canQueue() == %t for %s", !wantOK, state)
+		}
+		if q.queue(qf) != wantOK {
+			t.Fatalf("canQueue() == %t for %s", !wantOK, state)
+		}
+	}
+
+	for i := 0; i < N; i++ {
+		check("queue below cap", true)
+	}
+	check("full queue", false)
+	for i := 0; i < N; i++ {
+		if c := <-execd; c != i {
+			t.Fatal("execution out of order")
+		}
+	}
+	q.quit()
+	check("closed queue", false)
+}

--- a/les/handler.go
+++ b/les/handler.go
@@ -1057,10 +1057,8 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 				stats[i] = pm.txStatus([]common.Hash{hashes[i]})[0]
 			}
 		}
-
 		bv, rcost := p.fcClient.RequestProcessed(costs.baseCost + uint64(reqCnt)*costs.reqCost)
 		pm.server.fcCostStats.update(msg.Code, uint64(reqCnt), rcost)
-
 		return p.SendTxStatus(req.ReqID, bv, stats)
 
 	case GetTxStatusMsg:
@@ -1081,7 +1079,6 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		}
 		bv, rcost := p.fcClient.RequestProcessed(costs.baseCost + uint64(reqCnt)*costs.reqCost)
 		pm.server.fcCostStats.update(msg.Code, uint64(reqCnt), rcost)
-
 		return p.SendTxStatus(req.ReqID, bv, pm.txStatus(req.Hashes))
 
 	case TxStatusMsg:
@@ -1097,7 +1094,6 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		if err := msg.Decode(&resp); err != nil {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
-
 		p.fcServer.GotReply(resp.ReqID, resp.BV)
 
 	default:

--- a/les/handler.go
+++ b/les/handler.go
@@ -78,7 +78,7 @@ type BlockChain interface {
 	State() (*state.StateDB, error)
 	DposCtx() (*types.DposContext, error)
 	DposCtxAt(*types.DposContextRoot) (*types.DposContext, error)
-	InsertHeaderChain(chain []*types.Header, checkFreq int) (int, error)
+	InsertHeaderChain(chain types.HeaderInsertDataBatch, checkFreq int) (int, error)
 	Rollback(chain []common.Hash)
 	GetHeaderByNumber(number uint64) *types.Header
 	GetAncestor(hash common.Hash, number, ancestor uint64, maxNonCanonical *uint64) (common.Hash, uint64)

--- a/les/handler.go
+++ b/les/handler.go
@@ -1271,7 +1271,7 @@ func (ctx *dposProofMsgCtx) openDposCtx(blockHash common.Hash) {
 	ctx.lastBlockHash = blockHash
 }
 
-func selectDposTrie(dposCtx *types.DposContext, spec light.DposTrieSpecifier) *trie.Trie {
+func selectDposTrie(dposCtx *types.DposContext, spec light.DposTrieSpecifier) types.DposTrie {
 	switch spec {
 	case light.EpochTrieSpec:
 		return dposCtx.EpochTrie()

--- a/les/handler.go
+++ b/les/handler.go
@@ -324,7 +324,20 @@ func (pm *ProtocolManager) handle(p *peer) error {
 	}
 }
 
-var reqList = []uint64{GetBlockHeadersMsg, GetBlockBodiesMsg, GetCodeMsg, GetReceiptsMsg, GetProofsV1Msg, SendTxMsg, SendTxV2Msg, GetTxStatusMsg, GetHeaderProofsMsg, GetProofsV2Msg, GetHelperTrieProofsMsg}
+var reqList = []uint64{
+	GetBlockHeadersMsg,
+	GetBlockBodiesMsg,
+	GetCodeMsg,
+	GetReceiptsMsg,
+	GetProofsV1Msg,
+	SendTxMsg,
+	SendTxV2Msg,
+	GetTxStatusMsg,
+	GetHeaderProofsMsg,
+	GetProofsV2Msg,
+	GetHelperTrieProofsMsg,
+	GetDposTrieMsg,
+}
 
 // handleMsg is invoked whenever an inbound message is received from a remote
 // peer. The remote connection is torn down upon returning any error.

--- a/les/handler_test.go
+++ b/les/handler_test.go
@@ -1,0 +1,582 @@
+// Copyright 2019 DxChain, All rights reserved.
+// Use of this source code is governed by an Apache
+// License 2.0 that can be found in the LICENSE file.
+
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package les
+
+import (
+	"encoding/binary"
+	"math/big"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/DxChainNetwork/godx/common"
+	"github.com/DxChainNetwork/godx/consensus/ethash"
+	"github.com/DxChainNetwork/godx/core"
+	"github.com/DxChainNetwork/godx/core/rawdb"
+	"github.com/DxChainNetwork/godx/core/types"
+	"github.com/DxChainNetwork/godx/crypto"
+	"github.com/DxChainNetwork/godx/eth/downloader"
+	"github.com/DxChainNetwork/godx/ethdb"
+	"github.com/DxChainNetwork/godx/light"
+	"github.com/DxChainNetwork/godx/p2p"
+	"github.com/DxChainNetwork/godx/params"
+	"github.com/DxChainNetwork/godx/rlp"
+	"github.com/DxChainNetwork/godx/trie"
+)
+
+func expectResponse(r p2p.MsgReader, msgcode, reqID, bv uint64, data interface{}) error {
+	type resp struct {
+		ReqID, BV uint64
+		Data      interface{}
+	}
+	return p2p.ExpectMsg(r, msgcode, resp{reqID, bv, data})
+}
+
+// Tests that block headers can be retrieved from a remote chain based on user queries.
+func TestGetBlockHeadersLes1(t *testing.T) { testGetBlockHeaders(t, 1) }
+func TestGetBlockHeadersLes2(t *testing.T) { testGetBlockHeaders(t, 2) }
+
+func testGetBlockHeaders(t *testing.T, protocol int) {
+	server, tearDown := newServerEnv(t, downloader.MaxHashFetch+15, protocol, nil)
+	defer tearDown()
+	bc := server.pm.blockchain.(*core.BlockChain)
+
+	// Create a "random" unknown hash for testing
+	var unknown common.Hash
+	for i := range unknown {
+		unknown[i] = byte(i)
+	}
+	// Create a batch of tests for various scenarios
+	limit := uint64(MaxHeaderFetch)
+	tests := []struct {
+		query  *getBlockHeadersData // The query to execute for header retrieval
+		expect []common.Hash        // The hashes of the block whose headers are expected
+	}{
+		// A single random block should be retrievable by hash and number too
+		{
+			&getBlockHeadersData{Origin: hashOrNumber{Hash: bc.GetBlockByNumber(limit / 2).Hash()}, Amount: 1},
+			[]common.Hash{bc.GetBlockByNumber(limit / 2).Hash()},
+		}, {
+			&getBlockHeadersData{Origin: hashOrNumber{Number: limit / 2}, Amount: 1},
+			[]common.Hash{bc.GetBlockByNumber(limit / 2).Hash()},
+		},
+		// Multiple headers should be retrievable in both directions
+		{
+			&getBlockHeadersData{Origin: hashOrNumber{Number: limit / 2}, Amount: 3},
+			[]common.Hash{
+				bc.GetBlockByNumber(limit / 2).Hash(),
+				bc.GetBlockByNumber(limit/2 + 1).Hash(),
+				bc.GetBlockByNumber(limit/2 + 2).Hash(),
+			},
+		}, {
+			&getBlockHeadersData{Origin: hashOrNumber{Number: limit / 2}, Amount: 3, Reverse: true},
+			[]common.Hash{
+				bc.GetBlockByNumber(limit / 2).Hash(),
+				bc.GetBlockByNumber(limit/2 - 1).Hash(),
+				bc.GetBlockByNumber(limit/2 - 2).Hash(),
+			},
+		},
+		// Multiple headers with skip lists should be retrievable
+		{
+			&getBlockHeadersData{Origin: hashOrNumber{Number: limit / 2}, Skip: 3, Amount: 3},
+			[]common.Hash{
+				bc.GetBlockByNumber(limit / 2).Hash(),
+				bc.GetBlockByNumber(limit/2 + 4).Hash(),
+				bc.GetBlockByNumber(limit/2 + 8).Hash(),
+			},
+		}, {
+			&getBlockHeadersData{Origin: hashOrNumber{Number: limit / 2}, Skip: 3, Amount: 3, Reverse: true},
+			[]common.Hash{
+				bc.GetBlockByNumber(limit / 2).Hash(),
+				bc.GetBlockByNumber(limit/2 - 4).Hash(),
+				bc.GetBlockByNumber(limit/2 - 8).Hash(),
+			},
+		},
+		// The chain endpoints should be retrievable
+		{
+			&getBlockHeadersData{Origin: hashOrNumber{Number: 0}, Amount: 1},
+			[]common.Hash{bc.GetBlockByNumber(0).Hash()},
+		}, {
+			&getBlockHeadersData{Origin: hashOrNumber{Number: bc.CurrentBlock().NumberU64()}, Amount: 1},
+			[]common.Hash{bc.CurrentBlock().Hash()},
+		},
+		// Ensure protocol limits are honored
+		/*{
+			&getBlockHeadersData{Origin: hashOrNumber{Number: bc.CurrentBlock().NumberU64() - 1}, Amount: limit + 10, Reverse: true},
+			bc.GetBlockHashesFromHash(bc.CurrentBlock().Hash(), limit),
+		},*/
+		// Check that requesting more than available is handled gracefully
+		{
+			&getBlockHeadersData{Origin: hashOrNumber{Number: bc.CurrentBlock().NumberU64() - 4}, Skip: 3, Amount: 3},
+			[]common.Hash{
+				bc.GetBlockByNumber(bc.CurrentBlock().NumberU64() - 4).Hash(),
+				bc.GetBlockByNumber(bc.CurrentBlock().NumberU64()).Hash(),
+			},
+		}, {
+			&getBlockHeadersData{Origin: hashOrNumber{Number: 4}, Skip: 3, Amount: 3, Reverse: true},
+			[]common.Hash{
+				bc.GetBlockByNumber(4).Hash(),
+				bc.GetBlockByNumber(0).Hash(),
+			},
+		},
+		// Check that requesting more than available is handled gracefully, even if mid skip
+		{
+			&getBlockHeadersData{Origin: hashOrNumber{Number: bc.CurrentBlock().NumberU64() - 4}, Skip: 2, Amount: 3},
+			[]common.Hash{
+				bc.GetBlockByNumber(bc.CurrentBlock().NumberU64() - 4).Hash(),
+				bc.GetBlockByNumber(bc.CurrentBlock().NumberU64() - 1).Hash(),
+			},
+		}, {
+			&getBlockHeadersData{Origin: hashOrNumber{Number: 4}, Skip: 2, Amount: 3, Reverse: true},
+			[]common.Hash{
+				bc.GetBlockByNumber(4).Hash(),
+				bc.GetBlockByNumber(1).Hash(),
+			},
+		},
+		// Check that non existing headers aren't returned
+		{
+			&getBlockHeadersData{Origin: hashOrNumber{Hash: unknown}, Amount: 1},
+			[]common.Hash{},
+		}, {
+			&getBlockHeadersData{Origin: hashOrNumber{Number: bc.CurrentBlock().NumberU64() + 1}, Amount: 1},
+			[]common.Hash{},
+		},
+	}
+	// Run each of the tests and verify the results against the chain
+	var reqID uint64
+	for i, tt := range tests {
+		// Collect the headers to expect in the response
+		headers := []*types.Header{}
+		for _, hash := range tt.expect {
+			headers = append(headers, bc.GetHeaderByHash(hash))
+		}
+		// Send the hash request and verify the response
+		reqID++
+		cost := server.tPeer.GetRequestCost(GetBlockHeadersMsg, int(tt.query.Amount))
+		sendRequest(server.tPeer.app, GetBlockHeadersMsg, reqID, cost, tt.query)
+		if err := expectResponse(server.tPeer.app, BlockHeadersMsg, reqID, testBufLimit, headers); err != nil {
+			t.Errorf("test %d: headers mismatch: %v", i, err)
+		}
+	}
+}
+
+// Tests that block contents can be retrieved from a remote chain based on their hashes.
+func TestGetBlockBodiesLes1(t *testing.T) { testGetBlockBodies(t, 1) }
+func TestGetBlockBodiesLes2(t *testing.T) { testGetBlockBodies(t, 2) }
+
+func testGetBlockBodies(t *testing.T, protocol int) {
+	server, tearDown := newServerEnv(t, downloader.MaxBlockFetch+15, protocol, nil)
+	defer tearDown()
+	bc := server.pm.blockchain.(*core.BlockChain)
+
+	// Create a batch of tests for various scenarios
+	limit := MaxBodyFetch
+	tests := []struct {
+		random    int           // Number of blocks to fetch randomly from the chain
+		explicit  []common.Hash // Explicitly requested blocks
+		available []bool        // Availability of explicitly requested blocks
+		expected  int           // Total number of existing blocks to expect
+	}{
+		{1, nil, nil, 1},         // A single random block should be retrievable
+		{10, nil, nil, 10},       // Multiple random blocks should be retrievable
+		{limit, nil, nil, limit}, // The maximum possible blocks should be retrievable
+		//{limit + 1, nil, nil, limit},                                  // No more than the possible block count should be returned
+		{0, []common.Hash{bc.Genesis().Hash()}, []bool{true}, 1},      // The genesis block should be retrievable
+		{0, []common.Hash{bc.CurrentBlock().Hash()}, []bool{true}, 1}, // The chains head block should be retrievable
+		{0, []common.Hash{{}}, []bool{false}, 0},                      // A non existent block should not be returned
+
+		// Existing and non-existing blocks interleaved should not cause problems
+		{0, []common.Hash{
+			{},
+			bc.GetBlockByNumber(1).Hash(),
+			{},
+			bc.GetBlockByNumber(10).Hash(),
+			{},
+			bc.GetBlockByNumber(100).Hash(),
+			{},
+		}, []bool{false, true, false, true, false, true, false}, 3},
+	}
+	// Run each of the tests and verify the results against the chain
+	var reqID uint64
+	for i, tt := range tests {
+		// Collect the hashes to request, and the response to expect
+		hashes, seen := []common.Hash{}, make(map[int64]bool)
+		bodies := []*types.Body{}
+
+		for j := 0; j < tt.random; j++ {
+			for {
+				num := rand.Int63n(int64(bc.CurrentBlock().NumberU64()))
+				if !seen[num] {
+					seen[num] = true
+
+					block := bc.GetBlockByNumber(uint64(num))
+					hashes = append(hashes, block.Hash())
+					if len(bodies) < tt.expected {
+						bodies = append(bodies, &types.Body{Transactions: block.Transactions(), Uncles: block.Uncles()})
+					}
+					break
+				}
+			}
+		}
+		for j, hash := range tt.explicit {
+			hashes = append(hashes, hash)
+			if tt.available[j] && len(bodies) < tt.expected {
+				block := bc.GetBlockByHash(hash)
+				bodies = append(bodies, &types.Body{Transactions: block.Transactions(), Uncles: block.Uncles()})
+			}
+		}
+		reqID++
+		// Send the hash request and verify the response
+		cost := server.tPeer.GetRequestCost(GetBlockBodiesMsg, len(hashes))
+		sendRequest(server.tPeer.app, GetBlockBodiesMsg, reqID, cost, hashes)
+		if err := expectResponse(server.tPeer.app, BlockBodiesMsg, reqID, testBufLimit, bodies); err != nil {
+			t.Errorf("test %d: bodies mismatch: %v", i, err)
+		}
+	}
+}
+
+// Tests that the contract codes can be retrieved based on account addresses.
+func TestGetCodeLes1(t *testing.T) { testGetCode(t, 1) }
+func TestGetCodeLes2(t *testing.T) { testGetCode(t, 2) }
+
+func testGetCode(t *testing.T, protocol int) {
+	// Assemble the test environment
+	server, tearDown := newServerEnv(t, 4, protocol, nil)
+	defer tearDown()
+	bc := server.pm.blockchain.(*core.BlockChain)
+
+	var codereqs []*CodeReq
+	var codes [][]byte
+
+	for i := uint64(0); i <= bc.CurrentBlock().NumberU64(); i++ {
+		header := bc.GetHeaderByNumber(i)
+		req := &CodeReq{
+			BHash:  header.Hash(),
+			AccKey: crypto.Keccak256(testContractAddr[:]),
+		}
+		codereqs = append(codereqs, req)
+		if i >= testContractDeployed {
+			codes = append(codes, testContractCodeDeployed)
+		}
+	}
+
+	cost := server.tPeer.GetRequestCost(GetCodeMsg, len(codereqs))
+	sendRequest(server.tPeer.app, GetCodeMsg, 42, cost, codereqs)
+	if err := expectResponse(server.tPeer.app, CodeMsg, 42, testBufLimit, codes); err != nil {
+		t.Errorf("codes mismatch: %v", err)
+	}
+}
+
+// Tests that the transaction receipts can be retrieved based on hashes.
+func TestGetReceiptLes1(t *testing.T) { testGetReceipt(t, 1) }
+func TestGetReceiptLes2(t *testing.T) { testGetReceipt(t, 2) }
+
+func testGetReceipt(t *testing.T, protocol int) {
+	// Assemble the test environment
+	server, tearDown := newServerEnv(t, 4, protocol, nil)
+	defer tearDown()
+	bc := server.pm.blockchain.(*core.BlockChain)
+
+	// Collect the hashes to request, and the response to expect
+	hashes, receipts := []common.Hash{}, []types.Receipts{}
+	for i := uint64(0); i <= bc.CurrentBlock().NumberU64(); i++ {
+		block := bc.GetBlockByNumber(i)
+
+		hashes = append(hashes, block.Hash())
+		receipts = append(receipts, rawdb.ReadReceipts(server.db, block.Hash(), block.NumberU64()))
+	}
+	// Send the hash request and verify the response
+	cost := server.tPeer.GetRequestCost(GetReceiptsMsg, len(hashes))
+	sendRequest(server.tPeer.app, GetReceiptsMsg, 42, cost, hashes)
+	if err := expectResponse(server.tPeer.app, ReceiptsMsg, 42, testBufLimit, receipts); err != nil {
+		t.Errorf("receipts mismatch: %v", err)
+	}
+}
+
+// Tests that trie merkle proofs can be retrieved
+func TestGetProofsLes1(t *testing.T) { testGetProofs(t, 1) }
+func TestGetProofsLes2(t *testing.T) { testGetProofs(t, 2) }
+
+func testGetProofs(t *testing.T, protocol int) {
+	// Assemble the test environment
+	server, tearDown := newServerEnv(t, 4, protocol, nil)
+	defer tearDown()
+	bc := server.pm.blockchain.(*core.BlockChain)
+
+	var (
+		proofreqs []ProofReq
+		proofsV1  [][]rlp.RawValue
+	)
+	proofsV2 := light.NewNodeSet()
+
+	accounts := []common.Address{testBankAddress, acc1Addr, acc2Addr, {}}
+	for i := uint64(0); i <= bc.CurrentBlock().NumberU64(); i++ {
+		header := bc.GetHeaderByNumber(i)
+		root := header.Root
+		trie, _ := trie.New(root, trie.NewDatabase(server.db))
+
+		for _, acc := range accounts {
+			req := ProofReq{
+				BHash: header.Hash(),
+				Key:   crypto.Keccak256(acc[:]),
+			}
+			proofreqs = append(proofreqs, req)
+
+			switch protocol {
+			case 1:
+				var proof light.NodeList
+				trie.Prove(crypto.Keccak256(acc[:]), 0, &proof)
+				proofsV1 = append(proofsV1, proof)
+			case 2:
+				trie.Prove(crypto.Keccak256(acc[:]), 0, proofsV2)
+			}
+		}
+	}
+	// Send the proof request and verify the response
+	switch protocol {
+	case 1:
+		cost := server.tPeer.GetRequestCost(GetProofsV1Msg, len(proofreqs))
+		sendRequest(server.tPeer.app, GetProofsV1Msg, 42, cost, proofreqs)
+		if err := expectResponse(server.tPeer.app, ProofsV1Msg, 42, testBufLimit, proofsV1); err != nil {
+			t.Errorf("proofs mismatch: %v", err)
+		}
+	case 2:
+		cost := server.tPeer.GetRequestCost(GetProofsV2Msg, len(proofreqs))
+		sendRequest(server.tPeer.app, GetProofsV2Msg, 42, cost, proofreqs)
+		if err := expectResponse(server.tPeer.app, ProofsV2Msg, 42, testBufLimit, proofsV2.NodeList()); err != nil {
+			t.Errorf("proofs mismatch: %v", err)
+		}
+	}
+}
+
+// Tests that CHT proofs can be correctly retrieved.
+func TestGetCHTProofsLes1(t *testing.T) { testGetCHTProofs(t, 1) }
+func TestGetCHTProofsLes2(t *testing.T) { testGetCHTProofs(t, 2) }
+
+func testGetCHTProofs(t *testing.T, protocol int) {
+	config := light.TestServerIndexerConfig
+	frequency := config.ChtSize
+	if protocol == 2 {
+		frequency = config.PairChtSize
+	}
+
+	waitIndexers := func(cIndexer, bIndexer, btIndexer *core.ChainIndexer) {
+		expectSections := frequency / config.ChtSize
+		for {
+			cs, _, _ := cIndexer.Sections()
+			bs, _, _ := bIndexer.Sections()
+			if cs >= expectSections && bs >= expectSections {
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	server, tearDown := newServerEnv(t, int(frequency+config.ChtConfirms), protocol, waitIndexers)
+	defer tearDown()
+	bc := server.pm.blockchain.(*core.BlockChain)
+
+	// Assemble the proofs from the different protocols
+	header := bc.GetHeaderByNumber(frequency - 1)
+	rlp, _ := rlp.EncodeToBytes(header)
+
+	key := make([]byte, 8)
+	binary.BigEndian.PutUint64(key, frequency-1)
+
+	proofsV1 := []ChtResp{{
+		Header: header,
+	}}
+	proofsV2 := HelperTrieResps{
+		AuxData: [][]byte{rlp},
+	}
+	switch protocol {
+	case 1:
+		root := light.GetChtRoot(server.db, 0, bc.GetHeaderByNumber(frequency-1).Hash())
+		trie, _ := trie.New(root, trie.NewDatabase(ethdb.NewTable(server.db, light.ChtTablePrefix)))
+
+		var proof light.NodeList
+		trie.Prove(key, 0, &proof)
+		proofsV1[0].Proof = proof
+
+	case 2:
+		root := light.GetChtRoot(server.db, (frequency/config.ChtSize)-1, bc.GetHeaderByNumber(frequency-1).Hash())
+		trie, _ := trie.New(root, trie.NewDatabase(ethdb.NewTable(server.db, light.ChtTablePrefix)))
+		trie.Prove(key, 0, &proofsV2.Proofs)
+	}
+	// Assemble the requests for the different protocols
+	requestsV1 := []ChtReq{{
+		ChtNum:   frequency / config.ChtSize,
+		BlockNum: frequency - 1,
+	}}
+	requestsV2 := []HelperTrieReq{{
+		Type:    htCanonical,
+		TrieIdx: frequency/config.PairChtSize - 1,
+		Key:     key,
+		AuxReq:  auxHeader,
+	}}
+	// Send the proof request and verify the response
+	switch protocol {
+	case 1:
+		cost := server.tPeer.GetRequestCost(GetHeaderProofsMsg, len(requestsV1))
+		sendRequest(server.tPeer.app, GetHeaderProofsMsg, 42, cost, requestsV1)
+		if err := expectResponse(server.tPeer.app, HeaderProofsMsg, 42, testBufLimit, proofsV1); err != nil {
+			t.Errorf("proofs mismatch: %v", err)
+		}
+	case 2:
+		cost := server.tPeer.GetRequestCost(GetHelperTrieProofsMsg, len(requestsV2))
+		sendRequest(server.tPeer.app, GetHelperTrieProofsMsg, 42, cost, requestsV2)
+		if err := expectResponse(server.tPeer.app, HelperTrieProofsMsg, 42, testBufLimit, proofsV2); err != nil {
+			t.Errorf("proofs mismatch: %v", err)
+		}
+	}
+}
+
+// Tests that bloombits proofs can be correctly retrieved.
+func TestGetBloombitsProofs(t *testing.T) {
+	config := light.TestServerIndexerConfig
+
+	waitIndexers := func(cIndexer, bIndexer, btIndexer *core.ChainIndexer) {
+		for {
+			cs, _, _ := cIndexer.Sections()
+			bs, _, _ := bIndexer.Sections()
+			bts, _, _ := btIndexer.Sections()
+			if cs >= 8 && bs >= 8 && bts >= 1 {
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	server, tearDown := newServerEnv(t, int(config.BloomTrieSize+config.BloomTrieConfirms), 2, waitIndexers)
+	defer tearDown()
+	bc := server.pm.blockchain.(*core.BlockChain)
+
+	// Request and verify each bit of the bloom bits proofs
+	for bit := 0; bit < 2048; bit++ {
+		// Assemble the request and proofs for the bloombits
+		key := make([]byte, 10)
+
+		binary.BigEndian.PutUint16(key[:2], uint16(bit))
+		// Only the first bloom section has data.
+		binary.BigEndian.PutUint64(key[2:], 0)
+
+		requests := []HelperTrieReq{{
+			Type:    htBloomBits,
+			TrieIdx: 0,
+			Key:     key,
+		}}
+		var proofs HelperTrieResps
+
+		root := light.GetBloomTrieRoot(server.db, 0, bc.GetHeaderByNumber(config.BloomTrieSize-1).Hash())
+		trie, _ := trie.New(root, trie.NewDatabase(ethdb.NewTable(server.db, light.BloomTrieTablePrefix)))
+		trie.Prove(key, 0, &proofs.Proofs)
+
+		// Send the proof request and verify the response
+		cost := server.tPeer.GetRequestCost(GetHelperTrieProofsMsg, len(requests))
+		sendRequest(server.tPeer.app, GetHelperTrieProofsMsg, 42, cost, requests)
+		if err := expectResponse(server.tPeer.app, HelperTrieProofsMsg, 42, testBufLimit, proofs); err != nil {
+			t.Errorf("bit %d: proofs mismatch: %v", bit, err)
+		}
+	}
+}
+
+func TestTransactionStatusLes2(t *testing.T) {
+	db := ethdb.NewMemDatabase()
+	pm := newTestProtocolManagerMust(t, false, 0, nil, nil, nil, db)
+	chain := pm.blockchain.(*core.BlockChain)
+	config := core.DefaultTxPoolConfig
+	config.Journal = ""
+	txpool := core.NewTxPool(config, params.TestChainConfig, chain)
+	pm.txpool = txpool
+	peer, _ := newTestPeer(t, "peer", 2, pm, true)
+	defer peer.close()
+
+	var reqID uint64
+	test := func(tx *types.Transaction, send bool, expStatus txStatus) {
+		reqID++
+		if send {
+			enc, _ := rlp.EncodeToBytes(types.Transactions{tx})
+			cost := peer.GetRequestCost(GetTxStatusMsg, 1)
+			sendRequest(peer.app, SendTxV2Msg, reqID, cost, rlp.RawValue(enc))
+		} else {
+			cost := peer.GetRequestCost(GetTxStatusMsg, 1)
+			sendRequest(peer.app, GetTxStatusMsg, reqID, cost, []common.Hash{tx.Hash()})
+		}
+		if err := expectResponse(peer.app, TxStatusMsg, reqID, testBufLimit, []txStatus{expStatus}); err != nil {
+			t.Fatal("transaction status mismatch")
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	signer := types.HomesteadSigner{}
+	// test error status by sending an underpriced transaction
+	tx0, _ := types.SignTx(types.NewTransaction(0, acc1Addr, big.NewInt(10000), params.TxGas, nil, nil), signer, testBankKey)
+	test(tx0, true, txStatus{Status: core.TxStatusUnknown, Error: core.ErrUnderpriced.Error()})
+	tx1, _ := types.SignTx(types.NewTransaction(0, acc1Addr, big.NewInt(10000), params.TxGas, big.NewInt(100000000000), nil), signer, testBankKey)
+	test(tx1, false, txStatus{Status: core.TxStatusUnknown}) // query before sending, should be unknown
+	test(tx1, true, txStatus{Status: core.TxStatusPending})  // send valid processable tx, should return pending
+	test(tx1, true, txStatus{Status: core.TxStatusPending})  // adding it again should not return an error
+
+	tx2, _ := types.SignTx(types.NewTransaction(1, acc1Addr, big.NewInt(10000), params.TxGas, big.NewInt(100000000000), nil), signer, testBankKey)
+	tx3, _ := types.SignTx(types.NewTransaction(2, acc1Addr, big.NewInt(10000), params.TxGas, big.NewInt(100000000000), nil), signer, testBankKey)
+	// send transactions in the wrong order, tx3 should be queued
+	test(tx3, true, txStatus{Status: core.TxStatusQueued})
+	test(tx2, true, txStatus{Status: core.TxStatusPending})
+	// query again, now tx3 should be pending too
+	test(tx3, false, txStatus{Status: core.TxStatusPending})
+	// generate and add a block with tx1 and tx2 included
+	gchain, _ := core.GenerateChain(params.TestChainConfig, chain.GetBlockByNumber(0), ethash.NewFaker(), db, 1, func(i int, block *core.BlockGen) {
+		block.AddTx(tx1)
+		block.AddTx(tx2)
+	})
+	if _, err := chain.InsertChain(gchain); err != nil {
+		panic(err)
+	}
+	// wait until TxPool processes the inserted block
+	for i := 0; i < 10; i++ {
+		if pending, _ := txpool.Stats(); pending == 1 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if pending, _ := txpool.Stats(); pending != 1 {
+		t.Fatalf("pending count mismatch: have %d, want 1", pending)
+	}
+	// check if their status is included now
+	block1hash := rawdb.ReadCanonicalHash(db, 1)
+	test(tx1, false, txStatus{Status: core.TxStatusIncluded, Lookup: &rawdb.TxLookupEntry{BlockHash: block1hash, BlockIndex: 1, Index: 0}})
+	test(tx2, false, txStatus{Status: core.TxStatusIncluded, Lookup: &rawdb.TxLookupEntry{BlockHash: block1hash, BlockIndex: 1, Index: 1}})
+	// create a reorg that rolls them back
+	gchain, _ = core.GenerateChain(params.TestChainConfig, chain.GetBlockByNumber(0), ethash.NewFaker(), db, 2, func(i int, block *core.BlockGen) {})
+	if _, err := chain.InsertChain(gchain); err != nil {
+		panic(err)
+	}
+	// wait until TxPool processes the reorg
+	for i := 0; i < 10; i++ {
+		if pending, _ := txpool.Stats(); pending == 3 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if pending, _ := txpool.Stats(); pending != 3 {
+		t.Fatalf("pending count mismatch: have %d, want 3", pending)
+	}
+	// check if their status is pending again
+	test(tx1, false, txStatus{Status: core.TxStatusPending})
+	test(tx2, false, txStatus{Status: core.TxStatusPending})
+}

--- a/les/helper_test.go
+++ b/les/helper_test.go
@@ -178,7 +178,6 @@ func newTestProtocolManager(lightSync bool, blocks int, generator func(int, *cor
 		}
 		chain = blockchain
 	}
-
 	indexConfig := light.TestServerIndexerConfig
 	if lightSync {
 		indexConfig = light.TestClientIndexerConfig

--- a/les/helper_test.go
+++ b/les/helper_test.go
@@ -1,0 +1,452 @@
+// Copyright 2019 DxChain, All rights reserved.
+// Use of this source code is governed by an Apache
+// License 2.0 that can be found in the LICENSE file.
+
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// This file contains some shares testing functionality, common to  multiple
+// different files and modules being tested.
+
+package les
+
+import (
+	"crypto/rand"
+	"math/big"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/DxChainNetwork/godx/common"
+	"github.com/DxChainNetwork/godx/consensus/ethash"
+	"github.com/DxChainNetwork/godx/core"
+	"github.com/DxChainNetwork/godx/core/types"
+	"github.com/DxChainNetwork/godx/core/vm"
+	"github.com/DxChainNetwork/godx/crypto"
+	"github.com/DxChainNetwork/godx/eth"
+	"github.com/DxChainNetwork/godx/ethdb"
+	"github.com/DxChainNetwork/godx/event"
+	"github.com/DxChainNetwork/godx/les/flowcontrol"
+	"github.com/DxChainNetwork/godx/light"
+	"github.com/DxChainNetwork/godx/p2p"
+	"github.com/DxChainNetwork/godx/p2p/enode"
+	"github.com/DxChainNetwork/godx/params"
+)
+
+var (
+	testBankKey, _  = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	testBankAddress = crypto.PubkeyToAddress(testBankKey.PublicKey)
+	testBankFunds   = big.NewInt(1000000000000000000)
+
+	acc1Key, _ = crypto.HexToECDSA("8a1f9a8f95be41cd7ccb6168179afb4504aefe388d1e14474d32c45c72ce7b7a")
+	acc2Key, _ = crypto.HexToECDSA("49a7b37aa6f6645917e7b807e9d1c00d4fa71f18343b0d4122a4d2df64dd6fee")
+	acc1Addr   = crypto.PubkeyToAddress(acc1Key.PublicKey)
+	acc2Addr   = crypto.PubkeyToAddress(acc2Key.PublicKey)
+
+	testContractCode         = common.Hex2Bytes("606060405260cc8060106000396000f360606040526000357c01000000000000000000000000000000000000000000000000000000009004806360cd2685146041578063c16431b914606b57603f565b005b6055600480803590602001909190505060a9565b6040518082815260200191505060405180910390f35b60886004808035906020019091908035906020019091905050608a565b005b80600060005083606481101560025790900160005b50819055505b5050565b6000600060005082606481101560025790900160005b5054905060c7565b91905056")
+	testContractAddr         common.Address
+	testContractCodeDeployed = testContractCode[16:]
+	testContractDeployed     = uint64(2)
+
+	testEventEmitterCode = common.Hex2Bytes("60606040523415600e57600080fd5b7f57050ab73f6b9ebdd9f76b8d4997793f48cf956e965ee070551b9ca0bb71584e60405160405180910390a160358060476000396000f3006060604052600080fd00a165627a7a723058203f727efcad8b5811f8cb1fc2620ce5e8c63570d697aef968172de296ea3994140029")
+	testEventEmitterAddr common.Address
+
+	testBufLimit = uint64(100)
+)
+
+/*
+contract test {
+
+    uint256[100] data;
+
+    function Put(uint256 addr, uint256 value) {
+        data[addr] = value;
+    }
+
+    function Get(uint256 addr) constant returns (uint256 value) {
+        return data[addr];
+    }
+}
+*/
+
+func testChainGen(i int, block *core.BlockGen) {
+	signer := types.HomesteadSigner{}
+
+	switch i {
+	case 0:
+		// In block 1, the test bank sends account #1 some ether.
+		tx, _ := types.SignTx(types.NewTransaction(block.TxNonce(testBankAddress), acc1Addr, big.NewInt(10000), params.TxGas, nil, nil), signer, testBankKey)
+		block.AddTx(tx)
+	case 1:
+		// In block 2, the test bank sends some more ether to account #1.
+		// acc1Addr passes it on to account #2.
+		// acc1Addr creates a test contract.
+		// acc1Addr creates a test event.
+		nonce := block.TxNonce(acc1Addr)
+
+		tx1, _ := types.SignTx(types.NewTransaction(block.TxNonce(testBankAddress), acc1Addr, big.NewInt(1000), params.TxGas, nil, nil), signer, testBankKey)
+		tx2, _ := types.SignTx(types.NewTransaction(nonce, acc2Addr, big.NewInt(1000), params.TxGas, nil, nil), signer, acc1Key)
+		tx3, _ := types.SignTx(types.NewContractCreation(nonce+1, big.NewInt(0), 200000, big.NewInt(0), testContractCode), signer, acc1Key)
+		testContractAddr = crypto.CreateAddress(acc1Addr, nonce+1)
+		tx4, _ := types.SignTx(types.NewContractCreation(nonce+2, big.NewInt(0), 200000, big.NewInt(0), testEventEmitterCode), signer, acc1Key)
+		testEventEmitterAddr = crypto.CreateAddress(acc1Addr, nonce+2)
+		block.AddTx(tx1)
+		block.AddTx(tx2)
+		block.AddTx(tx3)
+		block.AddTx(tx4)
+	case 2:
+		// Block 3 is empty but was mined by account #2.
+		block.SetCoinbase(acc2Addr)
+		block.SetExtra([]byte("yeehaw"))
+		data := common.Hex2Bytes("C16431B900000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001")
+		tx, _ := types.SignTx(types.NewTransaction(block.TxNonce(testBankAddress), testContractAddr, big.NewInt(0), 100000, nil, data), signer, testBankKey)
+		block.AddTx(tx)
+	case 3:
+		// Block 4 includes blocks 2 and 3 as uncle headers (with modified extra data).
+		b2 := block.PrevBlock(1).Header()
+		b2.Extra = []byte("foo")
+		block.AddUncle(b2)
+		b3 := block.PrevBlock(2).Header()
+		b3.Extra = []byte("foo")
+		block.AddUncle(b3)
+		data := common.Hex2Bytes("C16431B900000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002")
+		tx, _ := types.SignTx(types.NewTransaction(block.TxNonce(testBankAddress), testContractAddr, big.NewInt(0), 100000, nil, data), signer, testBankKey)
+		block.AddTx(tx)
+	}
+}
+
+// testIndexers creates a set of indexers with specified params for testing purpose.
+func testIndexers(db ethdb.Database, odr light.OdrBackend, iConfig *light.IndexerConfig) (*core.ChainIndexer, *core.ChainIndexer, *core.ChainIndexer) {
+	chtIndexer := light.NewChtIndexer(db, odr, iConfig.ChtSize, iConfig.ChtConfirms)
+	bloomIndexer := eth.NewBloomIndexer(db, iConfig.BloomSize, iConfig.BloomConfirms)
+	bloomTrieIndexer := light.NewBloomTrieIndexer(db, odr, iConfig.BloomSize, iConfig.BloomTrieSize)
+	bloomIndexer.AddChildIndexer(bloomTrieIndexer)
+	return chtIndexer, bloomIndexer, bloomTrieIndexer
+}
+
+func testRCL() RequestCostList {
+	cl := make(RequestCostList, len(reqList))
+	for i, code := range reqList {
+		cl[i].MsgCode = code
+		cl[i].BaseCost = 0
+		cl[i].ReqCost = 0
+	}
+	return cl
+}
+
+// newTestProtocolManager creates a new protocol manager for testing purposes,
+// with the given number of blocks already known, potential notification
+// channels for different events and relative chain indexers array.
+func newTestProtocolManager(lightSync bool, blocks int, generator func(int, *core.BlockGen), odr *LesOdr, peers *peerSet, db ethdb.Database) (*ProtocolManager, error) {
+	var (
+		evmux  = new(event.TypeMux)
+		engine = ethash.NewFaker()
+		gspec  = &core.Genesis{
+			Config: params.TestChainConfig,
+			Alloc: core.MakeAlloc(
+				core.GenesisAlloc{testBankAddress: {Balance: testBankFunds}},
+				params.TestChainConfig,
+			),
+		}
+		genesis = gspec.MustCommit(db)
+		chain   BlockChain
+	)
+	if peers == nil {
+		peers = newPeerSet()
+	}
+
+	if lightSync {
+		chain, _ = light.NewLightChain(odr, gspec.Config, engine)
+	} else {
+		blockchain, _ := core.NewBlockChain(db, nil, gspec.Config, engine, vm.Config{}, nil)
+		gchain, _ := core.GenerateChain(gspec.Config, genesis, ethash.NewFaker(), db, blocks, generator)
+		if _, err := blockchain.InsertChain(gchain); err != nil {
+			panic(err)
+		}
+		chain = blockchain
+	}
+
+	indexConfig := light.TestServerIndexerConfig
+	if lightSync {
+		indexConfig = light.TestClientIndexerConfig
+	}
+	pm, err := NewProtocolManager(gspec.Config, indexConfig, lightSync, NetworkId, evmux, engine, peers, chain, nil, db, odr, nil, nil, make(chan struct{}), new(sync.WaitGroup))
+	if err != nil {
+		return nil, err
+	}
+	if !lightSync {
+		srv := &LesServer{lesCommons: lesCommons{protocolManager: pm}}
+		pm.server = srv
+
+		srv.defParams = &flowcontrol.ServerParams{
+			BufLimit:    testBufLimit,
+			MinRecharge: 1,
+		}
+
+		srv.fcManager = flowcontrol.NewClientManager(50, 10, 1000000000)
+		srv.fcCostStats = newCostStats(nil)
+	}
+	pm.Start(1000)
+	return pm, nil
+}
+
+// newTestProtocolManagerMust creates a new protocol manager for testing purposes,
+// with the given number of blocks already known, potential notification
+// channels for different events and relative chain indexers array. In case of an error, the constructor force-
+// fails the test.
+func newTestProtocolManagerMust(t *testing.T, lightSync bool, blocks int, generator func(int, *core.BlockGen), odr *LesOdr, peers *peerSet, db ethdb.Database) *ProtocolManager {
+	pm, err := newTestProtocolManager(lightSync, blocks, generator, odr, peers, db)
+	if err != nil {
+		t.Fatalf("Failed to create protocol manager: %v", err)
+	}
+	return pm
+}
+
+// testPeer is a simulated peer to allow testing direct network calls.
+type testPeer struct {
+	net p2p.MsgReadWriter // Network layer reader/writer to simulate remote messaging
+	app *p2p.MsgPipeRW    // Application layer reader/writer to simulate the local side
+	*peer
+}
+
+// newTestPeer creates a new peer registered at the given protocol manager.
+func newTestPeer(t *testing.T, name string, version int, pm *ProtocolManager, shake bool) (*testPeer, <-chan error) {
+	// Create a message pipe to communicate through
+	app, net := p2p.MsgPipe()
+
+	// Generate a random id and create the peer
+	var id enode.ID
+	rand.Read(id[:])
+
+	peer := pm.newPeer(version, NetworkId, p2p.NewPeer(id, name, nil), net)
+
+	// Start the peer on a new thread
+	errc := make(chan error, 1)
+	go func() {
+		select {
+		case pm.newPeerCh <- peer:
+			errc <- pm.handle(peer)
+		case <-pm.quitSync:
+			errc <- p2p.DiscQuitting
+		}
+	}()
+	tp := &testPeer{
+		app:  app,
+		net:  net,
+		peer: peer,
+	}
+	// Execute any implicitly requested handshakes and return
+	if shake {
+		var (
+			genesis = pm.blockchain.Genesis()
+			head    = pm.blockchain.CurrentHeader()
+			td      = pm.blockchain.GetTd(head.Hash(), head.Number.Uint64())
+		)
+		tp.handshake(t, td, head.Hash(), head.Number.Uint64(), genesis.Hash())
+	}
+	return tp, errc
+}
+
+func newTestPeerPair(name string, version int, pm, pm2 *ProtocolManager) (*peer, <-chan error, *peer, <-chan error) {
+	// Create a message pipe to communicate through
+	app, net := p2p.MsgPipe()
+
+	// Generate a random id and create the peer
+	var id enode.ID
+	rand.Read(id[:])
+
+	peer := pm.newPeer(version, NetworkId, p2p.NewPeer(id, name, nil), net)
+	peer2 := pm2.newPeer(version, NetworkId, p2p.NewPeer(id, name, nil), app)
+
+	// Start the peer on a new thread
+	errc := make(chan error, 1)
+	errc2 := make(chan error, 1)
+	go func() {
+		select {
+		case pm.newPeerCh <- peer:
+			errc <- pm.handle(peer)
+		case <-pm.quitSync:
+			errc <- p2p.DiscQuitting
+		}
+	}()
+	go func() {
+		select {
+		case pm2.newPeerCh <- peer2:
+			errc2 <- pm2.handle(peer2)
+		case <-pm2.quitSync:
+			errc2 <- p2p.DiscQuitting
+		}
+	}()
+	return peer, errc, peer2, errc2
+}
+
+// handshake simulates a trivial handshake that expects the same state from the
+// remote side as we are simulating locally.
+func (p *testPeer) handshake(t *testing.T, td *big.Int, head common.Hash, headNum uint64, genesis common.Hash) {
+	var expList keyValueList
+	expList = expList.add("protocolVersion", uint64(p.version))
+	expList = expList.add("networkId", uint64(NetworkId))
+	expList = expList.add("headTd", td)
+	expList = expList.add("headHash", head)
+	expList = expList.add("headNum", headNum)
+	expList = expList.add("genesisHash", genesis)
+	sendList := make(keyValueList, len(expList))
+	copy(sendList, expList)
+	expList = expList.add("serveHeaders", nil)
+	expList = expList.add("serveChainSince", uint64(0))
+	expList = expList.add("serveStateSince", uint64(0))
+	expList = expList.add("txRelay", nil)
+	expList = expList.add("flowControl/BL", testBufLimit)
+	expList = expList.add("flowControl/MRR", uint64(1))
+	expList = expList.add("flowControl/MRC", testRCL())
+
+	if err := p2p.ExpectMsg(p.app, StatusMsg, expList); err != nil {
+		t.Fatalf("status recv: %v", err)
+	}
+	if err := p2p.Send(p.app, StatusMsg, sendList); err != nil {
+		t.Fatalf("status send: %v", err)
+	}
+
+	p.fcServerParams = &flowcontrol.ServerParams{
+		BufLimit:    testBufLimit,
+		MinRecharge: 1,
+	}
+}
+
+// close terminates the local side of the peer, notifying the remote protocol
+// manager of termination.
+func (p *testPeer) close() {
+	p.app.Close()
+}
+
+// TestEntity represents a network entity for testing with necessary auxiliary fields.
+type TestEntity struct {
+	db    ethdb.Database
+	rPeer *peer
+	tPeer *testPeer
+	peers *peerSet
+	pm    *ProtocolManager
+	// Indexers
+	chtIndexer       *core.ChainIndexer
+	bloomIndexer     *core.ChainIndexer
+	bloomTrieIndexer *core.ChainIndexer
+}
+
+// newServerEnv creates a server testing environment with a connected test peer for testing purpose.
+func newServerEnv(t *testing.T, blocks int, protocol int, waitIndexers func(*core.ChainIndexer, *core.ChainIndexer, *core.ChainIndexer)) (*TestEntity, func()) {
+	db := ethdb.NewMemDatabase()
+	cIndexer, bIndexer, btIndexer := testIndexers(db, nil, light.TestServerIndexerConfig)
+
+	pm := newTestProtocolManagerMust(t, false, blocks, testChainGen, nil, nil, db)
+	peer, _ := newTestPeer(t, "peer", protocol, pm, true)
+
+	cIndexer.Start(pm.blockchain.(*core.BlockChain))
+	bIndexer.Start(pm.blockchain.(*core.BlockChain))
+
+	// Wait until indexers generate enough index data.
+	if waitIndexers != nil {
+		waitIndexers(cIndexer, bIndexer, btIndexer)
+	}
+
+	return &TestEntity{
+			db:               db,
+			tPeer:            peer,
+			pm:               pm,
+			chtIndexer:       cIndexer,
+			bloomIndexer:     bIndexer,
+			bloomTrieIndexer: btIndexer,
+		}, func() {
+			peer.close()
+			// Note bloom trie indexer will be closed by it parent recursively.
+			cIndexer.Close()
+			bIndexer.Close()
+		}
+}
+
+// newClientServerEnv creates a client/server arch environment with a connected les server and light client pair
+// for testing purpose.
+func newClientServerEnv(t *testing.T, blocks int, protocol int, waitIndexers func(*core.ChainIndexer, *core.ChainIndexer, *core.ChainIndexer), newPeer bool) (*TestEntity, *TestEntity, func()) {
+	db, ldb := ethdb.NewMemDatabase(), ethdb.NewMemDatabase()
+	peers, lPeers := newPeerSet(), newPeerSet()
+
+	dist := newRequestDistributor(lPeers, make(chan struct{}))
+	rm := newRetrieveManager(lPeers, dist, nil)
+	odr := NewLesOdr(ldb, light.TestClientIndexerConfig, rm)
+
+	cIndexer, bIndexer, btIndexer := testIndexers(db, nil, light.TestServerIndexerConfig)
+	lcIndexer, lbIndexer, lbtIndexer := testIndexers(ldb, odr, light.TestClientIndexerConfig)
+	odr.SetIndexers(lcIndexer, lbtIndexer, lbIndexer)
+
+	pm := newTestProtocolManagerMust(t, false, blocks, testChainGen, nil, peers, db)
+	lpm := newTestProtocolManagerMust(t, true, 0, nil, odr, lPeers, ldb)
+
+	startIndexers := func(clientMode bool, pm *ProtocolManager) {
+		if clientMode {
+			lcIndexer.Start(pm.blockchain.(*light.LightChain))
+			lbIndexer.Start(pm.blockchain.(*light.LightChain))
+		} else {
+			cIndexer.Start(pm.blockchain.(*core.BlockChain))
+			bIndexer.Start(pm.blockchain.(*core.BlockChain))
+		}
+	}
+
+	startIndexers(false, pm)
+	startIndexers(true, lpm)
+
+	// Execute wait until function if it is specified.
+	if waitIndexers != nil {
+		waitIndexers(cIndexer, bIndexer, btIndexer)
+	}
+
+	var (
+		peer, lPeer *peer
+		err1, err2  <-chan error
+	)
+	if newPeer {
+		peer, err1, lPeer, err2 = newTestPeerPair("peer", protocol, pm, lpm)
+		select {
+		case <-time.After(time.Millisecond * 100):
+		case err := <-err1:
+			t.Fatalf("peer 1 handshake error: %v", err)
+		case err := <-err2:
+			t.Fatalf("peer 2 handshake error: %v", err)
+		}
+	}
+
+	return &TestEntity{
+			db:               db,
+			pm:               pm,
+			rPeer:            peer,
+			peers:            peers,
+			chtIndexer:       cIndexer,
+			bloomIndexer:     bIndexer,
+			bloomTrieIndexer: btIndexer,
+		}, &TestEntity{
+			db:               ldb,
+			pm:               lpm,
+			rPeer:            lPeer,
+			peers:            lPeers,
+			chtIndexer:       lcIndexer,
+			bloomIndexer:     lbIndexer,
+			bloomTrieIndexer: lbtIndexer,
+		}, func() {
+			// Note bloom trie indexers will be closed by their parents recursively.
+			cIndexer.Close()
+			bIndexer.Close()
+			lcIndexer.Close()
+			lbIndexer.Close()
+		}
+}

--- a/les/odr.go
+++ b/les/odr.go
@@ -88,6 +88,7 @@ const (
 	MsgProofsV2
 	MsgHeaderProofs
 	MsgHelperTrieProofs
+	MsgDposProofs
 )
 
 // Msg encodes a LES message that delivers reply data for a request

--- a/les/odr_requests.go
+++ b/les/odr_requests.go
@@ -30,6 +30,7 @@ import (
 	"github.com/DxChainNetwork/godx/ethdb"
 	"github.com/DxChainNetwork/godx/light"
 	"github.com/DxChainNetwork/godx/log"
+	"github.com/DxChainNetwork/godx/p2p"
 	"github.com/DxChainNetwork/godx/rlp"
 	"github.com/DxChainNetwork/godx/trie"
 )
@@ -595,7 +596,7 @@ type DposTrieRequest light.DposTrieRequest
 
 // GetCost reeturn the cost of the request
 func (r *DposTrieRequest) GetCost(peer *peer) uint64 {
-	return peer.GetRequestCost(GetDposTrieMsg, 1)
+	return peer.GetRequestCost(GetDposProofMsg, 1)
 }
 
 // CanSend tells if a certain peer is suitable for serving the given request
@@ -627,4 +628,17 @@ func (r *DposTrieRequest) Validate(db ethdb.Database, msg *Msg) error {
 	}
 	r.Proof = nodeSet
 	return nil
+}
+
+type dposProofRequestPacket struct {
+	ReqID uint64
+	Reqs  []DposProofReq
+}
+
+func decodeDposProofMsg(msg p2p.Msg) (dposProofRequestPacket, error) {
+	var req dposProofRequestPacket
+	if err := msg.Decode(&req); err != nil {
+		return dposProofRequestPacket{}, err
+	}
+	return req, nil
 }

--- a/les/odr_requests.go
+++ b/les/odr_requests.go
@@ -578,3 +578,10 @@ func (db *readTraceDB) Has(key []byte) (bool, error) {
 	_, err := db.Get(key)
 	return err == nil, nil
 }
+
+// DposTrieRequest is the ODR request type for dpos trie
+type DposTrieRequest light.DposTrieRequest
+
+func (r *DposTrieRequest) GetCost(peer *peer) uint64 {
+
+}

--- a/les/peer.go
+++ b/les/peer.go
@@ -268,6 +268,11 @@ func (p *peer) SendTxStatus(reqID, bv uint64, stats []txStatus) error {
 	return sendResponse(p.rw, TxStatusMsg, reqID, bv, stats)
 }
 
+// SendDposProof sends a batch of nodes of proof, corresponding to the DposProof requested.
+func (p *peer) SendDposProof(reqID, bv uint64, proofs light.NodeList) error {
+	return sendResponse(p.rw, DposProofMsg, reqID, bv, proofs)
+}
+
 // RequestHeadersByHash fetches a batch of blocks' headers corresponding to the
 // specified header query, based on the hash of an origin block.
 func (p *peer) RequestHeadersByHash(reqID, cost uint64, origin common.Hash, amount int, skip int, reverse bool) error {
@@ -359,7 +364,7 @@ func (p *peer) SendTxs(reqID, cost uint64, txs types.Transactions) error {
 // RequestDposProof fetches a batch of dpos merkle proofs from a remote node
 func (p *peer) RequestDposProof(reqID, cost uint64, reqs []DposProofReq) error {
 	p.Log().Debug("Fetching batch of Dpos Proofs", "count", len(reqs))
-	return sendRequest(p.rw, GetDposTrieMsg, reqID, cost, reqs)
+	return sendRequest(p.rw, GetDposProofMsg, reqID, cost, reqs)
 }
 
 type keyValueEntry struct {

--- a/les/peer.go
+++ b/les/peer.go
@@ -356,6 +356,12 @@ func (p *peer) SendTxs(reqID, cost uint64, txs types.Transactions) error {
 	}
 }
 
+// RequestDposProof fetches a batch of dpos merkle proofs from a remote node
+func (p *peer) RequestDposProof(reqID, cost uint64, reqs []DposProofReq) error {
+	p.Log().Debug("Fetching batch of Dpos Proofs", "count", len(reqs))
+	return sendRequest(p.rw, GetDposTrieMsg, reqID, cost, reqs)
+}
+
 type keyValueEntry struct {
 	Key   string
 	Value rlp.RawValue

--- a/les/protocol.go
+++ b/les/protocol.go
@@ -79,6 +79,9 @@ const (
 	SendTxV2Msg            = 0x13
 	GetTxStatusMsg         = 0x14
 	TxStatusMsg            = 0x15
+	// Protocol for Dpos
+	GetDposTrieMsg = 0x16
+	DposTrieMsg    = 0x17
 )
 
 type errCode int

--- a/les/protocol.go
+++ b/les/protocol.go
@@ -80,8 +80,8 @@ const (
 	GetTxStatusMsg         = 0x14
 	TxStatusMsg            = 0x15
 	// Protocol for Dpos
-	GetDposTrieMsg = 0x16
-	DposTrieMsg    = 0x17
+	GetDposProofMsg = 0x16
+	DposProofMsg    = 0x17
 )
 
 type errCode int

--- a/les/randselect_test.go
+++ b/les/randselect_test.go
@@ -1,0 +1,67 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package les
+
+import (
+	"math/rand"
+	"testing"
+)
+
+type testWrsItem struct {
+	idx  int
+	widx *int
+}
+
+func (t *testWrsItem) Weight() int64 {
+	w := *t.widx
+	if w == -1 || w == t.idx {
+		return int64(t.idx + 1)
+	}
+	return 0
+}
+
+func TestWeightedRandomSelect(t *testing.T) {
+	testFn := func(cnt int) {
+		s := newWeightedRandomSelect()
+		w := -1
+		list := make([]testWrsItem, cnt)
+		for i := range list {
+			list[i] = testWrsItem{idx: i, widx: &w}
+			s.update(&list[i])
+		}
+		w = rand.Intn(cnt)
+		c := s.choose()
+		if c == nil {
+			t.Errorf("expected item, got nil")
+		} else {
+			if c.(*testWrsItem).idx != w {
+				t.Errorf("expected another item")
+			}
+		}
+		w = -2
+		if s.choose() != nil {
+			t.Errorf("expected nil, got item")
+		}
+	}
+	testFn(1)
+	testFn(10)
+	testFn(100)
+	testFn(1000)
+	testFn(10000)
+	testFn(100000)
+	testFn(1000000)
+}

--- a/les/request_test.go
+++ b/les/request_test.go
@@ -1,0 +1,126 @@
+// Copyright 2019 DxChain, All rights reserved.
+// Use of this source code is governed by an Apache
+// License 2.0 that can be found in the LICENSE file.
+
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package les
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DxChainNetwork/godx/common"
+	"github.com/DxChainNetwork/godx/core/rawdb"
+	"github.com/DxChainNetwork/godx/crypto"
+	"github.com/DxChainNetwork/godx/ethdb"
+	"github.com/DxChainNetwork/godx/light"
+)
+
+var testBankSecureTrieKey = secAddr(testBankAddress)
+
+func secAddr(addr common.Address) []byte {
+	return crypto.Keccak256(addr[:])
+}
+
+type accessTestFn func(db ethdb.Database, bhash common.Hash, number uint64) light.OdrRequest
+
+func TestBlockAccessLes1(t *testing.T) { testAccess(t, 1, tfBlockAccess) }
+
+func TestBlockAccessLes2(t *testing.T) { testAccess(t, 2, tfBlockAccess) }
+
+func tfBlockAccess(db ethdb.Database, bhash common.Hash, number uint64) light.OdrRequest {
+	return &light.BlockRequest{Hash: bhash, Number: number}
+}
+
+func TestReceiptsAccessLes1(t *testing.T) { testAccess(t, 1, tfReceiptsAccess) }
+
+func TestReceiptsAccessLes2(t *testing.T) { testAccess(t, 2, tfReceiptsAccess) }
+
+func tfReceiptsAccess(db ethdb.Database, bhash common.Hash, number uint64) light.OdrRequest {
+	return &light.ReceiptsRequest{Hash: bhash, Number: number}
+}
+
+func TestTrieEntryAccessLes1(t *testing.T) { testAccess(t, 1, tfTrieEntryAccess) }
+
+func TestTrieEntryAccessLes2(t *testing.T) { testAccess(t, 2, tfTrieEntryAccess) }
+
+func tfTrieEntryAccess(db ethdb.Database, bhash common.Hash, number uint64) light.OdrRequest {
+	if number := rawdb.ReadHeaderNumber(db, bhash); number != nil {
+		return &light.TrieRequest{Id: light.StateTrieID(rawdb.ReadHeader(db, bhash, *number)), Key: testBankSecureTrieKey}
+	}
+	return nil
+}
+
+func TestCodeAccessLes1(t *testing.T) { testAccess(t, 1, tfCodeAccess) }
+
+func TestCodeAccessLes2(t *testing.T) { testAccess(t, 2, tfCodeAccess) }
+
+func tfCodeAccess(db ethdb.Database, bhash common.Hash, num uint64) light.OdrRequest {
+	number := rawdb.ReadHeaderNumber(db, bhash)
+	if number != nil {
+		return nil
+	}
+	header := rawdb.ReadHeader(db, bhash, *number)
+	if header.Number.Uint64() < testContractDeployed {
+		return nil
+	}
+	sti := light.StateTrieID(header)
+	ci := light.StorageTrieID(sti, crypto.Keccak256Hash(testContractAddr[:]), common.Hash{})
+	return &light.CodeRequest{Id: ci, Hash: crypto.Keccak256Hash(testContractCodeDeployed)}
+}
+
+func testAccess(t *testing.T, protocol int, fn accessTestFn) {
+	// Assemble the test environment
+	server, client, tearDown := newClientServerEnv(t, 4, protocol, nil, true)
+	defer tearDown()
+	client.pm.synchronise(client.rPeer)
+
+	test := func(expFail uint64) {
+		for i := uint64(0); i <= server.pm.blockchain.CurrentHeader().Number.Uint64(); i++ {
+			bhash := rawdb.ReadCanonicalHash(server.db, i)
+			if req := fn(client.db, bhash, i); req != nil {
+				ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+				defer cancel()
+				err := client.pm.odr.Retrieve(ctx, req)
+				got := err == nil
+				exp := i < expFail
+				if exp && !got {
+					t.Errorf("object retrieval failed")
+				}
+				if !exp && got {
+					t.Errorf("unexpected object retrieval success")
+				}
+			}
+		}
+	}
+
+	// temporarily remove peer to test odr fails
+	client.peers.Unregister(client.rPeer.id)
+	time.Sleep(time.Millisecond * 10) // ensure that all peerSetNotify callbacks are executed
+	// expect retrievals to fail (except genesis block) without a les peer
+	test(0)
+
+	client.peers.Register(client.rPeer)
+	time.Sleep(time.Millisecond * 10) // ensure that all peerSetNotify callbacks are executed
+	client.rPeer.lock.Lock()
+	client.rPeer.hasBlock = func(common.Hash, uint64, bool) bool { return true }
+	client.rPeer.lock.Unlock()
+	// expect all retrievals to pass
+	test(5)
+}

--- a/les/txrelay.go
+++ b/les/txrelay.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/DxChainNetwork/godx/common"
 	"github.com/DxChainNetwork/godx/core/types"
+	"github.com/DxChainNetwork/godx/rlp"
 )
 
 type ltrInfo struct {
@@ -113,19 +114,20 @@ func (self *LesTxRelay) send(txs types.Transactions, count int) {
 	for p, list := range sendTo {
 		pp := p
 		ll := list
+		enc, _ := rlp.EncodeToBytes(ll)
 
 		reqID := genReqID()
 		rq := &distReq{
 			getCost: func(dp distPeer) uint64 {
 				peer := dp.(*peer)
-				return peer.GetRequestCost(SendTxMsg, len(ll))
+				return peer.GetTxRelayCost(len(ll), len(enc))
 			},
 			canSend: func(dp distPeer) bool {
 				return dp.(*peer) == pp
 			},
 			request: func(dp distPeer) func() {
 				peer := dp.(*peer)
-				cost := peer.GetRequestCost(SendTxMsg, len(ll))
+				cost := peer.GetTxRelayCost(len(ll), len(enc))
 				peer.fcServer.QueueRequest(reqID, cost)
 				return func() { peer.SendTxs(reqID, cost, ll) }
 			},

--- a/light/dpos_trie.go
+++ b/light/dpos_trie.go
@@ -3,3 +3,91 @@
 // License 2.0 that can be found in the LICENSE file
 
 package light
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/DxChainNetwork/godx/trie"
+
+	"github.com/DxChainNetwork/godx/common"
+	"github.com/DxChainNetwork/godx/core/types"
+)
+
+type dposDatabaseID struct {
+	blockHash   common.Hash
+	blockNumber uint64
+	roots       types.DposContextRoot
+}
+
+type dposOdrDatabase struct {
+	ctx     context.Context
+	id      *dposDatabaseID
+	backend OdrBackend
+}
+
+func NewOdrDposDatabase(ctx context.Context, header *types.Header, odr OdrBackend) *dposOdrDatabase {
+	return &dposOdrDatabase{
+		ctx:     ctx,
+		id:      DposDatabaseIDFromHeader(header),
+		backend: odr,
+	}
+}
+
+// DposTrieIDFromHeader returns a DposTrieID from a block header
+func DposDatabaseIDFromHeader(header *types.Header, trieSpec DposTrieSpecifier) *dposDatabaseID {
+	return &dposDatabaseID{
+		blockHash:   header.Hash(),
+		blockNumber: header.Number.Uint64(),
+		roots:       *header.DposContext.Copy(),
+	}
+}
+
+// dposDatabaseIDToTrieID convert a dposDatabaseID to DposTrieID
+func dposDatabaseIDToTrieID(id *dposDatabaseID, spec DposTrieSpecifier) *DposTrieID {
+	return &DposTrieID{
+		BlockHash: id.blockHash,
+		BlockNumber: id.blockNumber,
+		Roots: id.roots,
+		TrieSpec: spec,
+	}
+}
+
+// OpenEpochTrie opens the epoch trie
+func (db *dposOdrDatabase) OpenEpochTrie(root common.Hash) (*odrDposTrie, error) {
+	id := dposDatabaseIDToTrieID(db.id, EpochTrieSpec)
+	return &odrDposTrie {
+		db: db,
+		id: id,
+	}, nil
+}
+
+// OpenLastEpochTrie open the epoch trie in the last epoch
+func (db *dposOdrDatabase) OpenLastEpochTrie(root common.Hash) (*odrDposTrie, error) {
+	return nil, errors.New("light node does not support accumulate reward")
+}
+
+// OpenDelegateTrie open the delegate trie
+func (db *dposOdrDatabase) OpenDelegateTrie(root common.Hash) (*odrDposTrie, error) {
+	id := dposDatabaseIDToTrieID(db.id, DelegateTrieSpec)
+	return &odrDposTrie{
+		db: db,
+		id: id,
+	}, nil
+}
+
+func (db *dposOdrDatabase) OpenVoteTrie(root common.Hash) (*odrDposTrie, error) {
+	//id :=
+}
+
+func (db *dposOdrDatabase) openTrie(root common.Hash, spec DposTrieSpecifier) (*odrDposTrie, error) {
+
+}
+
+type odrDposTrie struct {
+	db *dposOdrDatabase
+	id *DposTrieID
+	trie *trie.Trie
+}
+
+func (t *odrTrie)

--- a/light/dpos_trie.go
+++ b/light/dpos_trie.go
@@ -55,38 +55,53 @@ func dposDatabaseIDToTrieID(id *dposDatabaseID, spec DposTrieSpecifier) *DposTri
 }
 
 // OpenEpochTrie opens the epoch trie
-func (db *dposOdrDatabase) OpenEpochTrie(root common.Hash) (*odrDposTrie, error) {
+func (db *dposOdrDatabase) OpenEpochTrie(root common.Hash) (types.DposTrie, error) {
 	return db.openTrie(EpochTrieSpec)
 }
 
 // OpenDelegateTrie open the delegate trie
-func (db *dposOdrDatabase) OpenDelegateTrie(root common.Hash) (*odrDposTrie, error) {
+func (db *dposOdrDatabase) OpenDelegateTrie(root common.Hash) (types.DposTrie, error) {
 	return db.openTrie(DelegateTrieSpec)
 }
 
 // OpenLastEpochTrie open the epoch trie in the last epoch
-func (db *dposOdrDatabase) OpenLastDelegateTrie(root common.Hash) (*odrDposTrie, error) {
+func (db *dposOdrDatabase) OpenLastDelegateTrie(root common.Hash) (types.DposTrie, error) {
 	return nil, errors.New("light node does not support accumulate reward")
 }
 
 // OpenVoteTrie open the vote trie
-func (db *dposOdrDatabase) OpenVoteTrie(root common.Hash) (*odrDposTrie, error) {
+func (db *dposOdrDatabase) OpenVoteTrie(root common.Hash) (types.DposTrie, error) {
 	return db.openTrie(VoteTrieSpec)
 }
 
 // OpenCandidateTrie opens the candidate trie
-func (db *dposOdrDatabase) OpenCandidateTrie(root common.Hash) (*odrDposTrie, error) {
+func (db *dposOdrDatabase) OpenCandidateTrie(root common.Hash) (types.DposTrie, error) {
 	return db.openTrie(CandidateTrieSpec)
 }
 
 // OpenMinedCntTrie opens the mined count trie
-func (db *dposOdrDatabase) OpenMinedCntTrie(root common.Hash) (*odrDposTrie, error) {
+func (db *dposOdrDatabase) OpenMinedCntTrie(root common.Hash) (types.DposTrie, error) {
 	return db.openTrie(MinedCntTrieSpec)
 }
 
-func (db *dposOdrDatabase) openTrie(spec DposTrieSpecifier) (*odrDposTrie, error) {
+func (db *dposOdrDatabase) openTrie(spec DposTrieSpecifier) (types.DposTrie, error) {
 	id := dposDatabaseIDToTrieID(db.id, spec)
 	return &odrDposTrie{db: db, id: id}, nil
+}
+
+// CopyTrie copies a dpos trie
+func (db *dposOdrDatabase) CopyTrie(t types.DposTrie) types.DposTrie {
+	switch t := t.(type) {
+	case *odrDposTrie:
+		cpy := &odrDposTrie{db: t.db, id: t.id}
+		if t.trie != nil {
+			cpyTrie := *t.trie
+			cpy.trie = &cpyTrie
+		}
+		return cpy
+	default:
+		panic(fmt.Errorf("unknown trie type %T", t))
+	}
 }
 
 // odrDposTrie is the trie data structure for light node which sits on top of lesOdrBackend that

--- a/light/dpos_trie.go
+++ b/light/dpos_trie.go
@@ -8,10 +8,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/DxChainNetwork/godx/trie"
 
 	"github.com/DxChainNetwork/godx/common"
 	"github.com/DxChainNetwork/godx/core/types"
+	"github.com/DxChainNetwork/godx/ethdb"
+	"github.com/DxChainNetwork/godx/trie"
 )
 
 type dposDatabaseID struct {
@@ -35,7 +36,7 @@ func NewOdrDposDatabase(ctx context.Context, header *types.Header, odr OdrBacken
 }
 
 // DposTrieIDFromHeader returns a DposTrieID from a block header
-func DposDatabaseIDFromHeader(header *types.Header, trieSpec DposTrieSpecifier) *dposDatabaseID {
+func DposDatabaseIDFromHeader(header *types.Header) *dposDatabaseID {
 	return &dposDatabaseID{
 		blockHash:   header.Hash(),
 		blockNumber: header.Number.Uint64(),
@@ -46,20 +47,16 @@ func DposDatabaseIDFromHeader(header *types.Header, trieSpec DposTrieSpecifier) 
 // dposDatabaseIDToTrieID convert a dposDatabaseID to DposTrieID
 func dposDatabaseIDToTrieID(id *dposDatabaseID, spec DposTrieSpecifier) *DposTrieID {
 	return &DposTrieID{
-		BlockHash: id.blockHash,
+		BlockHash:   id.blockHash,
 		BlockNumber: id.blockNumber,
-		Roots: id.roots,
-		TrieSpec: spec,
+		Roots:       id.roots,
+		TrieSpec:    spec,
 	}
 }
 
 // OpenEpochTrie opens the epoch trie
 func (db *dposOdrDatabase) OpenEpochTrie(root common.Hash) (*odrDposTrie, error) {
-	id := dposDatabaseIDToTrieID(db.id, EpochTrieSpec)
-	return &odrDposTrie {
-		db: db,
-		id: id,
-	}, nil
+	return db.openTrie(EpochTrieSpec)
 }
 
 // OpenLastEpochTrie open the epoch trie in the last epoch
@@ -69,25 +66,193 @@ func (db *dposOdrDatabase) OpenLastEpochTrie(root common.Hash) (*odrDposTrie, er
 
 // OpenDelegateTrie open the delegate trie
 func (db *dposOdrDatabase) OpenDelegateTrie(root common.Hash) (*odrDposTrie, error) {
-	id := dposDatabaseIDToTrieID(db.id, DelegateTrieSpec)
-	return &odrDposTrie{
-		db: db,
-		id: id,
-	}, nil
+	return db.openTrie(DelegateTrieSpec)
 }
 
+// OpenVoteTrie open the vote trie
 func (db *dposOdrDatabase) OpenVoteTrie(root common.Hash) (*odrDposTrie, error) {
-	//id :=
+	return db.openTrie(VoteTrieSpec)
 }
 
-func (db *dposOdrDatabase) openTrie(root common.Hash, spec DposTrieSpecifier) (*odrDposTrie, error) {
-
+// OpenCandidateTrie opens the candidate trie
+func (db *dposOdrDatabase) OpenCandidateTrie(root common.Hash) (*odrDposTrie, error) {
+	return db.openTrie(CandidateTrieSpec)
 }
 
+// OpenMinedCntTrie opens the mined count trie
+func (db *dposOdrDatabase) OpenMinedCntTrie(root common.Hash) (*odrDposTrie, error) {
+	return db.openTrie(MinedCntTrieSpec)
+}
+
+func (db *dposOdrDatabase) openTrie(spec DposTrieSpecifier) (*odrDposTrie, error) {
+	id := dposDatabaseIDToTrieID(db.id, spec)
+	return &odrDposTrie{db: db, id: id}, nil
+}
+
+// odrDposTrie is the trie data structure for light node which sits on top of lesOdrBackend that
+// helps retrieve trie data from the les server.
 type odrDposTrie struct {
-	db *dposOdrDatabase
-	id *DposTrieID
+	db   *dposOdrDatabase
+	id   *DposTrieID
 	trie *trie.Trie
 }
 
-func (t *odrTrie)
+// TryGet try to retrieve the value for the key
+func (t *odrDposTrie) TryGet(key []byte) ([]byte, error) {
+	var res []byte
+	err := t.do(key, func() (err error) {
+		res, err = t.trie.TryGet(key)
+		return err
+	})
+	return res, err
+}
+
+// TryUpdate try to update the key value pair in the trie
+func (t *odrDposTrie) TryUpdate(key, value []byte) error {
+	return t.do(key, func() error {
+		return t.trie.TryUpdate(key, value)
+	})
+}
+
+// TryDelete try to delete the key in the trie
+func (t *odrDposTrie) TryDelete(key []byte) error {
+	return t.do(key, func() error {
+		return t.trie.TryDelete(key)
+	})
+}
+
+// Commit commit the trie to trie db
+func (t *odrDposTrie) Commit(onleaf trie.LeafCallback) (common.Hash, error) {
+	if t.trie == nil {
+		return t.id.TargetRoot(), nil
+	}
+	return t.trie.Commit(onleaf)
+}
+
+// Hash returns the hash of the trie
+func (t *odrDposTrie) Hash() common.Hash {
+	if t.trie == nil {
+		return t.id.TargetRoot()
+	}
+	return t.trie.Hash()
+}
+
+// NodeIterator return the node iterator of the odrDposTrie
+func (t *odrDposTrie) NodeIterator(startKey []byte) trie.NodeIterator {
+	return newDposNodeIterator(t, startKey)
+}
+
+// PrefixIterator return the prefix iterator of the given prefix for the odrDposTrie.
+// Note that
+func (t *odrDposTrie) PrefixIterator(prefix []byte) trie.NodeIterator {
+	return newDposPrefixIterator(t, prefix)
+}
+
+// Prove put the proof of the specified key to proofDb
+func (t *odrDposTrie) Prove(key []byte, fromLevel uint, proofDb ethdb.Putter) error {
+	return errors.New("not implemented")
+}
+
+// do tries and retries to execute a function until it returns with no error or
+// an error type other than MissingNodeError
+func (t *odrDposTrie) do(key []byte, fn func() error) error {
+	for {
+		var err error
+		if t.trie == nil {
+			t.trie, err = trie.New(t.id.TargetRoot(), trie.NewDatabase(t.db.backend.Database()))
+		}
+		if err == nil {
+			err = fn()
+		}
+		if _, ok := err.(*trie.MissingNodeError); !ok {
+			return err
+		}
+		r := &DposTrieRequest{ID: t.id, Key: key}
+		if err := t.db.backend.Retrieve(t.db.ctx, r); err != nil {
+			return err
+		}
+	}
+}
+
+type dposNodeIterator struct {
+	trie.NodeIterator
+	t   *odrDposTrie
+	err error
+}
+
+// newDposPrefixIterator creates a dposNodeIterator which iterates over the given prefix
+// for the give odrDposTrie
+func newDposPrefixIterator(t *odrDposTrie, prefix []byte) trie.NodeIterator {
+	it := &dposNodeIterator{t: t}
+	if t.trie == nil {
+		it.do(func() error {
+			t, err := trie.New(t.id.TargetRoot(), trie.NewDatabase(t.db.backend.Database()))
+			if err == nil {
+				it.t.trie = t
+			}
+			return err
+		})
+	}
+	it.do(func() error {
+		it.NodeIterator = it.t.trie.PrefixIterator(prefix)
+		return it.NodeIterator.Error()
+	})
+	return it
+}
+
+// newDposNodeIterator creates a dposNodeIterator which iterates from the given key
+func newDposNodeIterator(t *odrDposTrie, start []byte) trie.NodeIterator {
+	it := &dposNodeIterator{t: t}
+	if t.trie == nil {
+		it.do(func() error {
+			t, err := trie.New(t.id.TargetRoot(), trie.NewDatabase(t.db.backend.Database()))
+			if err == nil {
+				it.t.trie = t
+			}
+			return err
+		})
+	}
+	it.do(func() error {
+		it.NodeIterator = it.t.trie.NodeIterator(start)
+		return it.NodeIterator.Error()
+	})
+	return it
+}
+
+// Next iterate to the next entry.
+func (it *dposNodeIterator) Next(descend bool) bool {
+	var ok bool
+	it.do(func() error {
+		ok = it.NodeIterator.Next(descend)
+		return it.NodeIterator.Error()
+	})
+	return ok
+}
+
+func (it *dposNodeIterator) do(fn func() error) {
+	var lastHash common.Hash
+	for {
+		it.err = fn()
+		missing, ok := it.err.(*trie.MissingNodeError)
+		if !ok {
+			return
+		}
+		if missing.NodeHash == lastHash {
+			it.err = fmt.Errorf("retrieve loop for trie node %x", missing.NodeHash)
+			return
+		}
+		lastHash = missing.NodeHash
+		r := &DposTrieRequest{ID: it.t.id, Key: nibblesToKey(missing.Path)}
+		if it.err = it.t.db.backend.Retrieve(it.t.db.ctx, r); it.err != nil {
+			return
+		}
+	}
+}
+
+// Error return the error for the node iterator
+func (it *dposNodeIterator) Error() error {
+	if it.err != nil {
+		return it.err
+	}
+	return it.NodeIterator.Error()
+}

--- a/light/dpos_trie.go
+++ b/light/dpos_trie.go
@@ -1,0 +1,5 @@
+// Copyright 2019 DxChain, All rights reserved.
+// Use of this source code is governed by an Apache
+// License 2.0 that can be found in the LICENSE file
+
+package light

--- a/light/dpos_trie.go
+++ b/light/dpos_trie.go
@@ -15,6 +15,13 @@ import (
 	"github.com/DxChainNetwork/godx/trie"
 )
 
+// NewDposContext creates a new dposContext
+func NewDposContext(ctx context.Context, header *types.Header, odr OdrBackend) *types.DposContext {
+	db := NewOdrDposDatabase(ctx, header, odr)
+	dposCtx, _ := types.NewDposContextFromProto(db, header.DposContext)
+	return dposCtx
+}
+
 type dposDatabaseID struct {
 	blockHash   common.Hash
 	blockNumber uint64

--- a/light/dpos_trie.go
+++ b/light/dpos_trie.go
@@ -59,14 +59,14 @@ func (db *dposOdrDatabase) OpenEpochTrie(root common.Hash) (*odrDposTrie, error)
 	return db.openTrie(EpochTrieSpec)
 }
 
-// OpenLastEpochTrie open the epoch trie in the last epoch
-func (db *dposOdrDatabase) OpenLastEpochTrie(root common.Hash) (*odrDposTrie, error) {
-	return nil, errors.New("light node does not support accumulate reward")
-}
-
 // OpenDelegateTrie open the delegate trie
 func (db *dposOdrDatabase) OpenDelegateTrie(root common.Hash) (*odrDposTrie, error) {
 	return db.openTrie(DelegateTrieSpec)
+}
+
+// OpenLastEpochTrie open the epoch trie in the last epoch
+func (db *dposOdrDatabase) OpenLastDelegateTrie(root common.Hash) (*odrDposTrie, error) {
+	return nil, errors.New("light node does not support accumulate reward")
 }
 
 // OpenVoteTrie open the vote trie

--- a/light/lightchain.go
+++ b/light/lightchain.go
@@ -215,6 +215,16 @@ func (bc *LightChain) State() (*state.StateDB, error) {
 	return nil, errors.New("not implemented, needs client/server interface split")
 }
 
+// DposCtx returns the dposCtx on the current head block
+func (bc *LightChain) DposCtx() (*types.DposContext, error) {
+	return nil, errors.New("not implemented")
+}
+
+// DposCtxAt returns the dposCtx given the dpos roots
+func (bc *LightChain) DposCtxAt(roots *types.DposContextRoot) (*types.DposContext, error) {
+	return nil, errors.New("not implemented")
+}
+
 // GetBody retrieves a block body (transactions and uncles) from the database
 // or ODR service by hash, caching it if found.
 func (self *LightChain) GetBody(ctx context.Context, hash common.Hash) (*types.Body, error) {

--- a/light/lightchain_test.go
+++ b/light/lightchain_test.go
@@ -1,0 +1,368 @@
+// Copyright 2019 DxChain, All rights reserved.
+// Use of this source code is governed by an Apache
+// License 2.0 that can be found in the LICENSE file.
+
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package light
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/DxChainNetwork/godx/common"
+	"github.com/DxChainNetwork/godx/consensus/ethash"
+	"github.com/DxChainNetwork/godx/core"
+	"github.com/DxChainNetwork/godx/core/rawdb"
+	"github.com/DxChainNetwork/godx/core/types"
+	"github.com/DxChainNetwork/godx/ethdb"
+	"github.com/DxChainNetwork/godx/params"
+)
+
+// So we can deterministically seed different blockchains
+var (
+	canonicalSeed = 1
+	forkSeed      = 2
+)
+
+// makeHeaderChain creates a deterministic chain of headers rooted at parent.
+func makeHeaderChain(parent *types.Header, n int, db ethdb.Database, seed int) []*types.Header {
+	blocks, _ := core.GenerateChain(params.TestChainConfig, types.NewBlockWithHeader(parent), ethash.NewFaker(), db, n, func(i int, b *core.BlockGen) {
+		b.SetCoinbase(common.Address{0: byte(seed), 19: byte(i)})
+	})
+	headers := make([]*types.Header, len(blocks))
+	for i, block := range blocks {
+		headers[i] = block.Header()
+	}
+	return headers
+}
+
+// newCanonical creates a chain database, and injects a deterministic canonical
+// chain. Depending on the full flag, if creates either a full block chain or a
+// header only chain.
+func newCanonical(n int) (ethdb.Database, *LightChain, error) {
+	db := ethdb.NewMemDatabase()
+	gspec := core.Genesis{
+		Config: params.TestChainConfig,
+		Alloc: core.MakeAlloc(
+			core.GenesisAlloc{},
+			params.TestChainConfig,
+		),
+	}
+	genesis := gspec.MustCommit(db)
+	blockchain, _ := NewLightChain(&dummyOdr{db: db, indexerConfig: TestClientIndexerConfig}, gspec.Config, ethash.NewFaker())
+
+	// Create and inject the requested chain
+	if n == 0 {
+		return db, blockchain, nil
+	}
+	// Header-only chain requested
+	headers := makeHeaderChain(genesis.Header(), n, db, canonicalSeed)
+	_, err := blockchain.InsertHeaderChain(headers, 1)
+	return db, blockchain, err
+}
+
+// newTestLightChain creates a LightChain that doesn't validate anything.
+func newTestLightChain() *LightChain {
+	db := ethdb.NewMemDatabase()
+	gspec := core.Genesis{
+		Config: params.TestChainConfig,
+		Alloc: core.MakeAlloc(
+			core.GenesisAlloc{},
+			params.TestChainConfig,
+		),
+		Difficulty: big.NewInt(1),
+	}
+	gspec.MustCommit(db)
+	lc, err := NewLightChain(&dummyOdr{db: db}, gspec.Config, ethash.NewFullFaker())
+	if err != nil {
+		panic(err)
+	}
+	return lc
+}
+
+// Test fork of length N starting from block i
+func testFork(t *testing.T, LightChain *LightChain, i, n int, comparator func(td1, td2 *big.Int)) {
+	// Copy old chain up to #i into a new db
+	db, LightChain2, err := newCanonical(i)
+	if err != nil {
+		t.Fatal("could not make new canonical in testFork", err)
+	}
+	// Assert the chains have the same header/block at #i
+	var hash1, hash2 common.Hash
+	hash1 = LightChain.GetHeaderByNumber(uint64(i)).Hash()
+	hash2 = LightChain2.GetHeaderByNumber(uint64(i)).Hash()
+	if hash1 != hash2 {
+		t.Errorf("chain content mismatch at %d: have hash %v, want hash %v", i, hash2, hash1)
+	}
+	// Extend the newly created chain
+	headerChainB := makeHeaderChain(LightChain2.CurrentHeader(), n, db, forkSeed)
+	if _, err := LightChain2.InsertHeaderChain(headerChainB, 1); err != nil {
+		t.Fatalf("failed to insert forking chain: %v", err)
+	}
+	// Sanity check that the forked chain can be imported into the original
+	var tdPre, tdPost *big.Int
+
+	tdPre = LightChain.GetTdByHash(LightChain.CurrentHeader().Hash())
+	if err := testHeaderChainImport(headerChainB, LightChain); err != nil {
+		t.Fatalf("failed to import forked header chain: %v", err)
+	}
+	tdPost = LightChain.GetTdByHash(headerChainB[len(headerChainB)-1].Hash())
+	// Compare the total difficulties of the chains
+	comparator(tdPre, tdPost)
+}
+
+// testHeaderChainImport tries to process a chain of header, writing them into
+// the database if successful.
+func testHeaderChainImport(chain []*types.Header, lightchain *LightChain) error {
+	for _, header := range chain {
+		// Try and validate the header
+		if err := lightchain.engine.VerifyHeader(lightchain.hc, header, true); err != nil {
+			return err
+		}
+		// Manually insert the header into the database, but don't reorganize (allows subsequent testing)
+		lightchain.mu.Lock()
+		rawdb.WriteTd(lightchain.chainDb, header.Hash(), header.Number.Uint64(), new(big.Int).Add(header.Difficulty, lightchain.GetTdByHash(header.ParentHash)))
+		rawdb.WriteHeader(lightchain.chainDb, header)
+		lightchain.mu.Unlock()
+	}
+	return nil
+}
+
+// Tests that given a starting canonical chain of a given size, it can be extended
+// with various length chains.
+func TestExtendCanonicalHeaders(t *testing.T) {
+	length := 5
+
+	// Make first chain starting from genesis
+	_, processor, err := newCanonical(length)
+	if err != nil {
+		t.Fatalf("failed to make new canonical chain: %v", err)
+	}
+	// Define the difficulty comparator
+	better := func(td1, td2 *big.Int) {
+		if td2.Cmp(td1) <= 0 {
+			t.Errorf("total difficulty mismatch: have %v, expected more than %v", td2, td1)
+		}
+	}
+	// Start fork from current height
+	testFork(t, processor, length, 1, better)
+	testFork(t, processor, length, 2, better)
+	testFork(t, processor, length, 5, better)
+	testFork(t, processor, length, 10, better)
+}
+
+// Tests that given a starting canonical chain of a given size, creating shorter
+// forks do not take canonical ownership.
+func TestShorterForkHeaders(t *testing.T) {
+	length := 10
+
+	// Make first chain starting from genesis
+	_, processor, err := newCanonical(length)
+	if err != nil {
+		t.Fatalf("failed to make new canonical chain: %v", err)
+	}
+	// Define the difficulty comparator
+	worse := func(td1, td2 *big.Int) {
+		if td2.Cmp(td1) >= 0 {
+			t.Errorf("total difficulty mismatch: have %v, expected less than %v", td2, td1)
+		}
+	}
+	// Sum of numbers must be less than `length` for this to be a shorter fork
+	testFork(t, processor, 0, 3, worse)
+	testFork(t, processor, 0, 7, worse)
+	testFork(t, processor, 1, 1, worse)
+	testFork(t, processor, 1, 7, worse)
+	testFork(t, processor, 5, 3, worse)
+	testFork(t, processor, 5, 4, worse)
+}
+
+// Tests that given a starting canonical chain of a given size, creating longer
+// forks do take canonical ownership.
+func TestLongerForkHeaders(t *testing.T) {
+	length := 10
+
+	// Make first chain starting from genesis
+	_, processor, err := newCanonical(length)
+	if err != nil {
+		t.Fatalf("failed to make new canonical chain: %v", err)
+	}
+	// Define the difficulty comparator
+	better := func(td1, td2 *big.Int) {
+		if td2.Cmp(td1) <= 0 {
+			t.Errorf("total difficulty mismatch: have %v, expected more than %v", td2, td1)
+		}
+	}
+	// Sum of numbers must be greater than `length` for this to be a longer fork
+	testFork(t, processor, 0, 11, better)
+	testFork(t, processor, 0, 15, better)
+	testFork(t, processor, 1, 10, better)
+	testFork(t, processor, 1, 12, better)
+	testFork(t, processor, 5, 6, better)
+	testFork(t, processor, 5, 8, better)
+}
+
+// Tests that given a starting canonical chain of a given size, creating equal
+// forks do take canonical ownership.
+func TestEqualForkHeaders(t *testing.T) {
+	length := 10
+
+	// Make first chain starting from genesis
+	_, processor, err := newCanonical(length)
+	if err != nil {
+		t.Fatalf("failed to make new canonical chain: %v", err)
+	}
+	// Define the difficulty comparator
+	equal := func(td1, td2 *big.Int) {
+		if td2.Cmp(td1) != 0 {
+			t.Errorf("total difficulty mismatch: have %v, want %v", td2, td1)
+		}
+	}
+	// Sum of numbers must be equal to `length` for this to be an equal fork
+	testFork(t, processor, 0, 10, equal)
+	testFork(t, processor, 1, 9, equal)
+	testFork(t, processor, 2, 8, equal)
+	testFork(t, processor, 5, 5, equal)
+	testFork(t, processor, 6, 4, equal)
+	testFork(t, processor, 9, 1, equal)
+}
+
+// Tests that chains missing links do not get accepted by the processor.
+func TestBrokenHeaderChain(t *testing.T) {
+	// Make chain starting from genesis
+	db, LightChain, err := newCanonical(10)
+	if err != nil {
+		t.Fatalf("failed to make new canonical chain: %v", err)
+	}
+	// Create a forked chain, and try to insert with a missing link
+	chain := makeHeaderChain(LightChain.CurrentHeader(), 5, db, forkSeed)[1:]
+	if err := testHeaderChainImport(chain, LightChain); err == nil {
+		t.Errorf("broken header chain not reported")
+	}
+}
+
+func makeHeaderChainWithDiff(genesis *types.Block, d []int, seed byte) []*types.Header {
+	var chain []*types.Header
+	for i, difficulty := range d {
+		header := &types.Header{
+			Coinbase:    common.Address{seed},
+			Number:      big.NewInt(int64(i + 1)),
+			Difficulty:  big.NewInt(int64(difficulty)),
+			UncleHash:   types.EmptyUncleHash,
+			TxHash:      types.EmptyRootHash,
+			ReceiptHash: types.EmptyRootHash,
+		}
+		if i == 0 {
+			header.ParentHash = genesis.Hash()
+		} else {
+			header.ParentHash = chain[i-1].Hash()
+		}
+		chain = append(chain, types.CopyHeader(header))
+	}
+	return chain
+}
+
+type dummyOdr struct {
+	OdrBackend
+	db            ethdb.Database
+	indexerConfig *IndexerConfig
+}
+
+func (odr *dummyOdr) Database() ethdb.Database {
+	return odr.db
+}
+
+func (odr *dummyOdr) Retrieve(ctx context.Context, req OdrRequest) error {
+	return nil
+}
+
+func (odr *dummyOdr) IndexerConfig() *IndexerConfig {
+	return odr.indexerConfig
+}
+
+// Tests that reorganizing a long difficult chain after a short easy one
+// overwrites the canonical numbers and links in the database.
+func TestReorgLongHeaders(t *testing.T) {
+	testReorg(t, []int{1, 2, 4}, []int{1, 2, 3, 4}, 10)
+}
+
+// Tests that reorganizing a short difficult chain after a long easy one
+// overwrites the canonical numbers and links in the database.
+func TestReorgShortHeaders(t *testing.T) {
+	testReorg(t, []int{1, 2, 3, 4}, []int{1, 10}, 11)
+}
+
+func testReorg(t *testing.T, first, second []int, td int64) {
+	bc := newTestLightChain()
+
+	// Insert an easy and a difficult chain afterwards
+	bc.InsertHeaderChain(makeHeaderChainWithDiff(bc.genesisBlock, first, 11), 1)
+	bc.InsertHeaderChain(makeHeaderChainWithDiff(bc.genesisBlock, second, 22), 1)
+	// Check that the chain is valid number and link wise
+	prev := bc.CurrentHeader()
+	for header := bc.GetHeaderByNumber(bc.CurrentHeader().Number.Uint64() - 1); header.Number.Uint64() != 0; prev, header = header, bc.GetHeaderByNumber(header.Number.Uint64()-1) {
+		if prev.ParentHash != header.Hash() {
+			t.Errorf("parent header hash mismatch: have %x, want %x", prev.ParentHash, header.Hash())
+		}
+	}
+	// Make sure the chain total difficulty is the correct one
+	want := new(big.Int).Add(bc.genesisBlock.Difficulty(), big.NewInt(td))
+	if have := bc.GetTdByHash(bc.CurrentHeader().Hash()); have.Cmp(want) != 0 {
+		t.Errorf("total difficulty mismatch: have %v, want %v", have, want)
+	}
+}
+
+// Tests that the insertion functions detect banned hashes.
+func TestBadHeaderHashes(t *testing.T) {
+	bc := newTestLightChain()
+
+	// Create a chain, ban a hash and try to import
+	var err error
+	headers := makeHeaderChainWithDiff(bc.genesisBlock, []int{1, 2, 4}, 10)
+	core.BadHashes[headers[2].Hash()] = true
+	if _, err = bc.InsertHeaderChain(headers, 1); err != core.ErrBlacklistedHash {
+		t.Errorf("error mismatch: have: %v, want %v", err, core.ErrBlacklistedHash)
+	}
+}
+
+// Tests that bad hashes are detected on boot, and the chan rolled back to a
+// good state prior to the bad hash.
+func TestReorgBadHeaderHashes(t *testing.T) {
+	bc := newTestLightChain()
+
+	// Create a chain, import and ban afterwards
+	headers := makeHeaderChainWithDiff(bc.genesisBlock, []int{1, 2, 3, 4}, 10)
+
+	if _, err := bc.InsertHeaderChain(headers, 1); err != nil {
+		t.Fatalf("failed to import headers: %v", err)
+	}
+	if bc.CurrentHeader().Hash() != headers[3].Hash() {
+		t.Errorf("last header hash mismatch: have: %x, want %x", bc.CurrentHeader().Hash(), headers[3].Hash())
+	}
+	core.BadHashes[headers[3].Hash()] = true
+	defer func() { delete(core.BadHashes, headers[3].Hash()) }()
+
+	// Create a new LightChain and check that it rolled back the state.
+	ncm, err := NewLightChain(&dummyOdr{db: bc.chainDb}, params.TestChainConfig, ethash.NewFaker())
+	if err != nil {
+		t.Fatalf("failed to create new chain manager: %v", err)
+	}
+	if ncm.CurrentHeader().Hash() != headers[2].Hash() {
+		t.Errorf("last header hash mismatch: have: %x, want %x", ncm.CurrentHeader().Hash(), headers[2].Hash())
+	}
+}

--- a/light/odr.go
+++ b/light/odr.go
@@ -177,3 +177,60 @@ func (req *BloomRequest) StoreResult(db ethdb.Database) {
 		rawdb.WriteBloomBits(db, req.BitIdx, sectionIdx, sectionHead, req.BloomBits[i])
 	}
 }
+
+// DposTrieSpecifier is the specifier for dpos tries, which tell which trie to retrieve
+type DposTrieSpecifier uint8
+
+const (
+	EpochTrieSpec DposTrieSpecifier = iota + 1
+	DelegateTrieSpec
+	CandidateTrieSpec
+	VoteTrieSpec
+	MinedCntTrieSpec
+)
+
+func (spec DposTrieSpecifier) String() string {
+	switch spec {
+	case EpochTrieSpec:
+		return "epoch trie"
+	case DelegateTrieSpec:
+		return "delegate trie"
+	case CandidateTrieSpec:
+		return "candidate trie"
+	case VoteTrieSpec:
+		return "vote trie"
+	case MinedCntTrieSpec:
+		return "mined count trie"
+	default:
+	}
+	return "unknown dpos trie specifier"
+}
+
+// DposTrieID is the ID for DposTries
+type DposTrieID struct {
+	BlockHash   common.Hash
+	BlockNumber uint64
+	Roots       types.DposContextRoot
+}
+
+// DposTrieIDFromHeader returns a DposTrieID from a block header
+func DposTrieIDFromHeader(header *types.Header) *DposTrieID {
+	return &DposTrieID{
+		BlockHash:   header.Hash(),
+		BlockNumber: header.Number.Uint64(),
+		Roots:       *header.DposContext.Copy(),
+	}
+}
+
+// DposTrieRequest is the ODR request type for retrieving dpos related trie
+type DposTrieRequest struct {
+	OdrRequest
+	ID    *DposTrieID
+	Key   []byte
+	Proof *NodeSet
+}
+
+// StoreResult stores the result of DposTrieRequest into the database
+func (req *DposTrieRequest) StoreResult(db ethdb.Database) {
+	req.Proof.Store(db)
+}

--- a/light/odr.go
+++ b/light/odr.go
@@ -211,15 +211,35 @@ type DposTrieID struct {
 	BlockHash   common.Hash
 	BlockNumber uint64
 	Roots       types.DposContextRoot
+	TrieSpec    DposTrieSpecifier
 }
 
 // DposTrieIDFromHeader returns a DposTrieID from a block header
-func DposTrieIDFromHeader(header *types.Header) *DposTrieID {
+func DposTrieIDFromHeader(header *types.Header, trieSpec DposTrieSpecifier) *DposTrieID {
 	return &DposTrieID{
 		BlockHash:   header.Hash(),
 		BlockNumber: header.Number.Uint64(),
 		Roots:       *header.DposContext.Copy(),
+		TrieSpec:    trieSpec,
 	}
+}
+
+// TargetRoot return the target root for a DposTrieID
+func (id *DposTrieID) TargetRoot() common.Hash {
+	switch id.TrieSpec {
+	case EpochTrieSpec:
+		return id.Roots.EpochRoot
+	case DelegateTrieSpec:
+		return id.Roots.DelegateRoot
+	case CandidateTrieSpec:
+		return id.Roots.CandidateRoot
+	case VoteTrieSpec:
+		return id.Roots.VoteRoot
+	case MinedCntTrieSpec:
+		return id.Roots.MinedCntRoot
+	default:
+	}
+	return common.Hash{}
 }
 
 // DposTrieRequest is the ODR request type for retrieving dpos related trie

--- a/light/odr.go
+++ b/light/odr.go
@@ -214,16 +214,6 @@ type DposTrieID struct {
 	TrieSpec    DposTrieSpecifier
 }
 
-// DposTrieIDFromHeader returns a DposTrieID from a block header
-func DposTrieIDFromHeader(header *types.Header, trieSpec DposTrieSpecifier) *DposTrieID {
-	return &DposTrieID{
-		BlockHash:   header.Hash(),
-		BlockNumber: header.Number.Uint64(),
-		Roots:       *header.DposContext.Copy(),
-		TrieSpec:    trieSpec,
-	}
-}
-
 // TargetRoot return the target root for a DposTrieID
 func (id *DposTrieID) TargetRoot() common.Hash {
 	switch id.TrieSpec {

--- a/light/odr_test.go
+++ b/light/odr_test.go
@@ -1,0 +1,327 @@
+// Copyright 2019 DxChain, All rights reserved.
+// Use of this source code is governed by an Apache
+// License 2.0 that can be found in the LICENSE file.
+
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package light
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/DxChainNetwork/godx/common"
+	"github.com/DxChainNetwork/godx/consensus/ethash"
+	"github.com/DxChainNetwork/godx/core"
+	"github.com/DxChainNetwork/godx/core/rawdb"
+	"github.com/DxChainNetwork/godx/core/state"
+	"github.com/DxChainNetwork/godx/core/types"
+	"github.com/DxChainNetwork/godx/core/vm"
+	"github.com/DxChainNetwork/godx/crypto"
+	"github.com/DxChainNetwork/godx/ethdb"
+	"github.com/DxChainNetwork/godx/params"
+	"github.com/DxChainNetwork/godx/rlp"
+	"github.com/DxChainNetwork/godx/trie"
+)
+
+var (
+	testBankKey, _  = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	testBankAddress = crypto.PubkeyToAddress(testBankKey.PublicKey)
+	testBankFunds   = big.NewInt(100000000)
+
+	acc1Key, _ = crypto.HexToECDSA("8a1f9a8f95be41cd7ccb6168179afb4504aefe388d1e14474d32c45c72ce7b7a")
+	acc2Key, _ = crypto.HexToECDSA("49a7b37aa6f6645917e7b807e9d1c00d4fa71f18343b0d4122a4d2df64dd6fee")
+	acc1Addr   = crypto.PubkeyToAddress(acc1Key.PublicKey)
+	acc2Addr   = crypto.PubkeyToAddress(acc2Key.PublicKey)
+
+	testContractCode = common.Hex2Bytes("606060405260cc8060106000396000f360606040526000357c01000000000000000000000000000000000000000000000000000000009004806360cd2685146041578063c16431b914606b57603f565b005b6055600480803590602001909190505060a9565b6040518082815260200191505060405180910390f35b60886004808035906020019091908035906020019091905050608a565b005b80600060005083606481101560025790900160005b50819055505b5050565b6000600060005082606481101560025790900160005b5054905060c7565b91905056")
+	testContractAddr common.Address
+)
+
+type testOdr struct {
+	OdrBackend
+	indexerConfig *IndexerConfig
+	sdb, ldb      ethdb.Database
+	disable       bool
+}
+
+func (odr *testOdr) Database() ethdb.Database {
+	return odr.ldb
+}
+
+var ErrOdrDisabled = errors.New("ODR disabled")
+
+func (odr *testOdr) Retrieve(ctx context.Context, req OdrRequest) error {
+	if odr.disable {
+		return ErrOdrDisabled
+	}
+	switch req := req.(type) {
+	case *BlockRequest:
+		number := rawdb.ReadHeaderNumber(odr.sdb, req.Hash)
+		if number != nil {
+			req.Rlp = rawdb.ReadBodyRLP(odr.sdb, req.Hash, *number)
+		}
+	case *ReceiptsRequest:
+		number := rawdb.ReadHeaderNumber(odr.sdb, req.Hash)
+		if number != nil {
+			req.Receipts = rawdb.ReadReceipts(odr.sdb, req.Hash, *number)
+		}
+	case *TrieRequest:
+		t, _ := trie.New(req.Id.Root, trie.NewDatabase(odr.sdb))
+		nodes := NewNodeSet()
+		t.Prove(req.Key, 0, nodes)
+		req.Proof = nodes
+	case *CodeRequest:
+		req.Data, _ = odr.sdb.Get(req.Hash[:])
+	}
+	req.StoreResult(odr.ldb)
+	return nil
+}
+
+func (odr *testOdr) IndexerConfig() *IndexerConfig {
+	return odr.indexerConfig
+}
+
+type odrTestFn func(ctx context.Context, db ethdb.Database, bc *core.BlockChain, lc *LightChain, bhash common.Hash) ([]byte, error)
+
+func TestOdrGetBlockLes1(t *testing.T) { testChainOdr(t, 1, odrGetBlock) }
+
+func odrGetBlock(ctx context.Context, db ethdb.Database, bc *core.BlockChain, lc *LightChain, bhash common.Hash) ([]byte, error) {
+	var block *types.Block
+	if bc != nil {
+		block = bc.GetBlockByHash(bhash)
+	} else {
+		block, _ = lc.GetBlockByHash(ctx, bhash)
+	}
+	if block == nil {
+		return nil, nil
+	}
+	rlp, _ := rlp.EncodeToBytes(block)
+	return rlp, nil
+}
+
+func TestOdrGetReceiptsLes1(t *testing.T) { testChainOdr(t, 1, odrGetReceipts) }
+
+func odrGetReceipts(ctx context.Context, db ethdb.Database, bc *core.BlockChain, lc *LightChain, bhash common.Hash) ([]byte, error) {
+	var receipts types.Receipts
+	if bc != nil {
+		number := rawdb.ReadHeaderNumber(db, bhash)
+		if number != nil {
+			receipts = rawdb.ReadReceipts(db, bhash, *number)
+		}
+	} else {
+		number := rawdb.ReadHeaderNumber(db, bhash)
+		if number != nil {
+			receipts, _ = GetBlockReceipts(ctx, lc.Odr(), bhash, *number)
+		}
+	}
+	if receipts == nil {
+		return nil, nil
+	}
+	rlp, _ := rlp.EncodeToBytes(receipts)
+	return rlp, nil
+}
+
+func TestOdrAccountsLes1(t *testing.T) { testChainOdr(t, 1, odrAccounts) }
+
+func odrAccounts(ctx context.Context, db ethdb.Database, bc *core.BlockChain, lc *LightChain, bhash common.Hash) ([]byte, error) {
+	dummyAddr := common.HexToAddress("1234567812345678123456781234567812345678")
+	acc := []common.Address{testBankAddress, acc1Addr, acc2Addr, dummyAddr}
+
+	var st *state.StateDB
+	if bc == nil {
+		header := lc.GetHeaderByHash(bhash)
+		st = NewState(ctx, header, lc.Odr())
+	} else {
+		header := bc.GetHeaderByHash(bhash)
+		st, _ = state.New(header.Root, state.NewDatabase(db))
+	}
+
+	var res []byte
+	for _, addr := range acc {
+		bal := st.GetBalance(addr)
+		rlp, _ := rlp.EncodeToBytes(bal)
+		res = append(res, rlp...)
+	}
+	return res, st.Error()
+}
+
+// TODO: enable this when finished implementation of dpos trie
+//func TestOdrContractCallLes1(t *testing.T) { testChainOdr(t, 1, odrContractCall) }
+//
+//type callmsg struct {
+//	types.Message
+//}
+//
+//func (callmsg) CheckNonce() bool { return false }
+//
+//func odrContractCall(ctx context.Context, db ethdb.Database, bc *core.BlockChain, lc *LightChain, bhash common.Hash) ([]byte, error) {
+//	data := common.Hex2Bytes("60CD26850000000000000000000000000000000000000000000000000000000000000000")
+//	config := params.TestChainConfig
+//
+//	var res []byte
+//	for i := 0; i < 3; i++ {
+//		data[35] = byte(i)
+//
+//		var (
+//			st     *state.StateDB
+//			header *types.Header
+//			chain  core.ChainContext
+//		)
+//		if bc == nil {
+//			chain = lc
+//			header = lc.GetHeaderByHash(bhash)
+//			st = NewState(ctx, header, lc.Odr())
+//		} else {
+//			chain = bc
+//			header = bc.GetHeaderByHash(bhash)
+//			st, _ = state.New(header.Root, state.NewDatabase(db))
+//		}
+//
+//		// Perform read-only call.
+//		st.SetBalance(testBankAddress, math.MaxBig256)
+//		msg := callmsg{types.NewMessage(testBankAddress, &testContractAddr, 0, new(big.Int), 1000000, new(big.Int), data, false)}
+//		context := core.NewEVMContext(msg, header, chain, nil)
+//		vmenv := vm.NewEVM(context, st, config, vm.Config{})
+//		gp := new(core.GasPool).AddGas(math.MaxUint64)
+//		ret, _, _, _ := core.ApplyMessage(vmenv, msg, gp)
+//		res = append(res, ret...)
+//		if st.Error() != nil {
+//			return res, st.Error()
+//		}
+//	}
+//	return res, nil
+//}
+
+func testChainGen(i int, block *core.BlockGen) {
+	signer := types.HomesteadSigner{}
+	switch i {
+	case 0:
+		// In block 1, the test bank sends account #1 some ether.
+		tx, _ := types.SignTx(types.NewTransaction(block.TxNonce(testBankAddress), acc1Addr, big.NewInt(10000), params.TxGas, nil, nil), signer, testBankKey)
+		block.AddTx(tx)
+	case 1:
+		// In block 2, the test bank sends some more ether to account #1.
+		// acc1Addr passes it on to account #2.
+		// acc1Addr creates a test contract.
+		tx1, _ := types.SignTx(types.NewTransaction(block.TxNonce(testBankAddress), acc1Addr, big.NewInt(1000), params.TxGas, nil, nil), signer, testBankKey)
+		nonce := block.TxNonce(acc1Addr)
+		tx2, _ := types.SignTx(types.NewTransaction(nonce, acc2Addr, big.NewInt(1000), params.TxGas, nil, nil), signer, acc1Key)
+		nonce++
+		tx3, _ := types.SignTx(types.NewContractCreation(nonce, big.NewInt(0), 1000000, big.NewInt(0), testContractCode), signer, acc1Key)
+		testContractAddr = crypto.CreateAddress(acc1Addr, nonce)
+		block.AddTx(tx1)
+		block.AddTx(tx2)
+		block.AddTx(tx3)
+	case 2:
+		// Block 3 is empty but was mined by account #2.
+		block.SetCoinbase(acc2Addr)
+		block.SetExtra([]byte("yeehaw"))
+		data := common.Hex2Bytes("C16431B900000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001")
+		tx, _ := types.SignTx(types.NewTransaction(block.TxNonce(testBankAddress), testContractAddr, big.NewInt(0), 100000, nil, data), signer, testBankKey)
+		block.AddTx(tx)
+	case 3:
+		// Block 4 includes blocks 2 and 3 as uncle headers (with modified extra data).
+		b2 := block.PrevBlock(1).Header()
+		b2.Extra = []byte("foo")
+		block.AddUncle(b2)
+		b3 := block.PrevBlock(2).Header()
+		b3.Extra = []byte("foo")
+		block.AddUncle(b3)
+		data := common.Hex2Bytes("C16431B900000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002")
+		tx, _ := types.SignTx(types.NewTransaction(block.TxNonce(testBankAddress), testContractAddr, big.NewInt(0), 100000, nil, data), signer, testBankKey)
+		block.AddTx(tx)
+	}
+}
+
+func testChainOdr(t *testing.T, protocol int, fn odrTestFn) {
+	var (
+		sdb   = ethdb.NewMemDatabase()
+		ldb   = ethdb.NewMemDatabase()
+		gspec = core.Genesis{
+			Config: params.TestChainConfig,
+			Alloc: core.MakeAlloc(
+				core.GenesisAlloc{testBankAddress: {Balance: testBankFunds}},
+				params.TestChainConfig,
+			),
+		}
+		genesis = gspec.MustCommit(sdb)
+	)
+	gspec.MustCommit(ldb)
+	// Assemble the test environment
+	blockchain, _ := core.NewBlockChain(sdb, nil, params.TestChainConfig, ethash.NewFullFaker(), vm.Config{}, nil)
+	gchain, _ := core.GenerateChain(params.TestChainConfig, genesis, ethash.NewFaker(), sdb, 4, testChainGen)
+	if _, err := blockchain.InsertChain(gchain); err != nil {
+		t.Fatal(err)
+	}
+
+	odr := &testOdr{sdb: sdb, ldb: ldb, indexerConfig: TestClientIndexerConfig}
+	lightchain, err := NewLightChain(odr, params.TestChainConfig, ethash.NewFullFaker())
+	if err != nil {
+		t.Fatal(err)
+	}
+	headers := make([]*types.Header, len(gchain))
+	for i, block := range gchain {
+		headers[i] = block.Header()
+	}
+	if _, err := lightchain.InsertHeaderChain(headers, 1); err != nil {
+		t.Fatal(err)
+	}
+
+	test := func(expFail int) {
+		for i := uint64(0); i <= blockchain.CurrentHeader().Number.Uint64(); i++ {
+			bhash := rawdb.ReadCanonicalHash(sdb, i)
+			b1, err := fn(NoOdr, sdb, blockchain, nil, bhash)
+			if err != nil {
+				t.Fatalf("error in full-node test for block %d: %v", i, err)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+			defer cancel()
+
+			exp := i < uint64(expFail)
+			b2, err := fn(ctx, ldb, nil, lightchain, bhash)
+			if err != nil && exp {
+				t.Errorf("error in ODR test for block %d: %v", i, err)
+			}
+
+			eq := bytes.Equal(b1, b2)
+			if exp && !eq {
+				t.Errorf("ODR test output for block %d doesn't match full node", i)
+			}
+		}
+	}
+
+	// expect retrievals to fail (except genesis block) without a les peer
+	t.Log("checking without ODR")
+	odr.disable = true
+	test(1)
+
+	// expect all retrievals to pass with ODR enabled
+	t.Log("checking with ODR")
+	odr.disable = false
+	test(len(gchain))
+
+	// still expect all retrievals to pass, now data should be cached locally
+	t.Log("checking without ODR, should be cached")
+	odr.disable = true
+	test(len(gchain))
+}

--- a/light/trie_test.go
+++ b/light/trie_test.go
@@ -1,0 +1,92 @@
+// Copyright 2019 DxChain, All rights reserved.
+// Use of this source code is governed by an Apache
+// License 2.0 that can be found in the LICENSE file.
+
+// Copyright 2017 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package light
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/DxChainNetwork/godx/consensus/ethash"
+	"github.com/DxChainNetwork/godx/core"
+	"github.com/DxChainNetwork/godx/core/state"
+	"github.com/DxChainNetwork/godx/core/vm"
+	"github.com/DxChainNetwork/godx/ethdb"
+	"github.com/DxChainNetwork/godx/params"
+	"github.com/DxChainNetwork/godx/trie"
+	"github.com/davecgh/go-spew/spew"
+)
+
+func TestNodeIterator(t *testing.T) {
+	var (
+		fulldb  = ethdb.NewMemDatabase()
+		lightdb = ethdb.NewMemDatabase()
+		gspec   = core.Genesis{
+			Config: params.TestChainConfig,
+			Alloc: core.MakeAlloc(
+				core.GenesisAlloc{testBankAddress: {Balance: testBankFunds}},
+				params.TestChainConfig,
+			),
+		}
+		genesis = gspec.MustCommit(fulldb)
+	)
+	gspec.MustCommit(lightdb)
+	blockchain, _ := core.NewBlockChain(fulldb, nil, params.TestChainConfig, ethash.NewFullFaker(), vm.Config{}, nil)
+	gchain, _ := core.GenerateChain(params.TestChainConfig, genesis, ethash.NewFaker(), fulldb, 4, testChainGen)
+	if _, err := blockchain.InsertChain(gchain); err != nil {
+		panic(err)
+	}
+
+	ctx := context.Background()
+	odr := &testOdr{sdb: fulldb, ldb: lightdb, indexerConfig: TestClientIndexerConfig}
+	head := blockchain.CurrentHeader()
+	lightTrie, _ := NewStateDatabase(ctx, head, odr).OpenTrie(head.Root)
+	fullTrie, _ := state.NewDatabase(fulldb).OpenTrie(head.Root)
+	if err := diffTries(fullTrie, lightTrie); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func diffTries(t1, t2 state.Trie) error {
+	i1 := trie.NewIterator(t1.NodeIterator(nil))
+	i2 := trie.NewIterator(t2.NodeIterator(nil))
+	for i1.Next() && i2.Next() {
+		if !bytes.Equal(i1.Key, i2.Key) {
+			spew.Dump(i2)
+			return fmt.Errorf("tries have different keys %x, %x", i1.Key, i2.Key)
+		}
+		if !bytes.Equal(i1.Value, i2.Value) {
+			return fmt.Errorf("tries differ at key %x", i1.Key)
+		}
+	}
+	switch {
+	case i1.Err != nil:
+		return fmt.Errorf("full trie iterator error: %v", i1.Err)
+	case i2.Err != nil:
+		return fmt.Errorf("light trie iterator error: %v", i1.Err)
+	case i1.Next():
+		return fmt.Errorf("full trie iterator has more k/v pairs")
+	case i2.Next():
+		return fmt.Errorf("light trie iterator has more k/v pairs")
+	}
+	return nil
+}

--- a/light/txpool_test.go
+++ b/light/txpool_test.go
@@ -1,0 +1,149 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package light
+
+import (
+	"context"
+	"math"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/DxChainNetwork/godx/common"
+	"github.com/DxChainNetwork/godx/consensus/ethash"
+	"github.com/DxChainNetwork/godx/core"
+	"github.com/DxChainNetwork/godx/core/types"
+	"github.com/DxChainNetwork/godx/core/vm"
+	"github.com/DxChainNetwork/godx/ethdb"
+	"github.com/DxChainNetwork/godx/params"
+)
+
+type testTxRelay struct {
+	send, discard, mined chan int
+}
+
+func (self *testTxRelay) Send(txs types.Transactions) {
+	self.send <- len(txs)
+}
+
+func (self *testTxRelay) NewHead(head common.Hash, mined []common.Hash, rollback []common.Hash) {
+	m := len(mined)
+	if m != 0 {
+		self.mined <- m
+	}
+}
+
+func (self *testTxRelay) Discard(hashes []common.Hash) {
+	self.discard <- len(hashes)
+}
+
+const poolTestTxs = 1000
+const poolTestBlocks = 100
+
+// test tx 0..n-1
+var testTx [poolTestTxs]*types.Transaction
+
+// txs sent before block i
+func sentTx(i int) int {
+	return int(math.Pow(float64(i)/float64(poolTestBlocks), 0.9) * poolTestTxs)
+}
+
+// txs included in block i or before that (minedTx(i) <= sentTx(i))
+func minedTx(i int) int {
+	return int(math.Pow(float64(i)/float64(poolTestBlocks), 1.1) * poolTestTxs)
+}
+
+func txPoolTestChainGen(i int, block *core.BlockGen) {
+	s := minedTx(i)
+	e := minedTx(i + 1)
+	for i := s; i < e; i++ {
+		block.AddTx(testTx[i])
+	}
+}
+
+func TestTxPool(t *testing.T) {
+	for i := range testTx {
+		testTx[i], _ = types.SignTx(types.NewTransaction(uint64(i), acc1Addr, big.NewInt(10000), params.TxGas, nil, nil), types.HomesteadSigner{}, testBankKey)
+	}
+
+	var (
+		sdb   = ethdb.NewMemDatabase()
+		ldb   = ethdb.NewMemDatabase()
+		gspec = core.Genesis{
+			Config: params.TestChainConfig,
+			Alloc: core.MakeAlloc(
+				core.GenesisAlloc{testBankAddress: {Balance: testBankFunds}},
+				params.TestChainConfig,
+			),
+		}
+		genesis = gspec.MustCommit(sdb)
+	)
+	gspec.MustCommit(ldb)
+	// Assemble the test environment
+	blockchain, _ := core.NewBlockChain(sdb, nil, params.TestChainConfig, ethash.NewFullFaker(), vm.Config{}, nil)
+	gchain, _ := core.GenerateChain(params.TestChainConfig, genesis, ethash.NewFaker(), sdb, poolTestBlocks, txPoolTestChainGen)
+	if _, err := blockchain.InsertChain(gchain); err != nil {
+		panic(err)
+	}
+
+	odr := &testOdr{sdb: sdb, ldb: ldb, indexerConfig: TestClientIndexerConfig}
+	relay := &testTxRelay{
+		send:    make(chan int, 1),
+		discard: make(chan int, 1),
+		mined:   make(chan int, 1),
+	}
+	lightchain, _ := NewLightChain(odr, params.TestChainConfig, ethash.NewFullFaker())
+	txPermanent = 50
+	pool := NewTxPool(params.TestChainConfig, lightchain, relay)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	for ii, block := range gchain {
+		i := ii + 1
+		s := sentTx(i - 1)
+		e := sentTx(i)
+		for i := s; i < e; i++ {
+			pool.Add(ctx, testTx[i])
+			got := <-relay.send
+			exp := 1
+			if got != exp {
+				t.Errorf("relay.Send expected len = %d, got %d", exp, got)
+			}
+		}
+
+		if _, err := lightchain.InsertHeaderChain([]*types.Header{block.Header()}, 1); err != nil {
+			panic(err)
+		}
+
+		got := <-relay.mined
+		exp := minedTx(i) - minedTx(i-1)
+		if got != exp {
+			t.Errorf("relay.NewHead expected len(mined) = %d, got %d", exp, got)
+		}
+
+		exp = 0
+		if i > int(txPermanent)+1 {
+			exp = minedTx(i-int(txPermanent)-1) - minedTx(i-int(txPermanent)-2)
+		}
+		if exp != 0 {
+			got = <-relay.discard
+			if got != exp {
+				t.Errorf("relay.Discard expected len = %d, got %d", exp, got)
+			}
+		}
+	}
+}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -500,7 +500,7 @@ func (w *worker) makeCurrent(parent *types.Block, header *types.Header) error {
 
 	// construct dpos context from parent's dpos context root
 	chainDB := stateDB.Database().TrieDB().DiskDB().(ethdb.Database)
-	dposContext, err := types.NewDposContextFromProto(types.NewDposDb(chainDB), parent.Header().DposContext)
+	dposContext, err := types.NewDposContextFromProto(types.NewFullDposDatabase(chainDB), parent.Header().DposContext)
 	if err != nil {
 		log.Error("failed to create dpos context", "error", err)
 		return err

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -500,7 +500,7 @@ func (w *worker) makeCurrent(parent *types.Block, header *types.Header) error {
 
 	// construct dpos context from parent's dpos context root
 	chainDB := stateDB.Database().TrieDB().DiskDB().(ethdb.Database)
-	dposContext, err := types.NewDposContextFromProto(chainDB, parent.Header().DposContext)
+	dposContext, err := types.NewDposContextFromProto(types.NewDposDb(chainDB), parent.Header().DposContext)
 	if err != nil {
 		log.Error("failed to create dpos context", "error", err)
 		return err

--- a/params/config.go
+++ b/params/config.go
@@ -25,8 +25,8 @@ import (
 
 // Genesis hashes to enforce below configs on.
 var (
-	MainnetGenesisHash = common.HexToHash("22fb425009102548ecc0a720068b7c2deeb146072d65c396aa0a33a7bd01cbea")
-	TestnetGenesisHash = common.HexToHash("b35da689074a7313d5d19cc6d5fd4cca47d9f36d00f995096c7e750384cfef3e")
+	MainnetGenesisHash = common.HexToHash("0xf23ba5f615f1001641d1b2241771cc3de5baa52c98e3b09b6bbd3f3b96f09ec0")
+	TestnetGenesisHash = common.HexToHash("0x5751c2f5c2489e7535909c4ec36c18bdb3da7a78191a100c04650af85d08216a")
 	RinkebyGenesisHash = common.HexToHash("0x6341fd3daf94b748c72ced5a5b26028f2474f5f00d824504e4fa37a75767e177")
 )
 

--- a/params/config.go
+++ b/params/config.go
@@ -136,7 +136,7 @@ var (
 	// adding flags to the config to also have to set these fields.
 	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}, nil}
 
-	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, nil}
+	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, DefaultDposConfig()}
 	TestRules       = TestChainConfig.Rules(new(big.Int))
 )
 

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -21,9 +21,8 @@ type (
 	//
 	// Trie is not safe for concurrent use.
 	Trie struct {
-		db     *Database
-		root   node
-		prefix []byte
+		db   *Database
+		root node
 
 		// Cache generation values.
 		// cachegen increases by one each commit operation
@@ -84,33 +83,15 @@ func New(root common.Hash, db *Database) (*Trie, error) {
 	return trie, nil
 }
 
-// NewTrieWithPrefix creates a trie with an existing root node that has the specified prefix
-func NewTrieWithPrefix(root common.Hash, prefix []byte, db *Database) (*Trie, error) {
-	trie, err := New(root, db)
-	if err != nil {
-		return nil, err
-	}
-	trie.prefix = prefix
-	return trie, nil
-}
-
 // NodeIterator returns an iterator that returns nodes of the trie. Iteration
 // starts at the key after the given start key
 func (t *Trie) NodeIterator(start []byte) NodeIterator {
-	if t.prefix != nil {
-		start = append(t.prefix, start...)
-	}
-
 	return newNodeIterator(t, start)
 }
 
 // PrefixIterator returns an iterator that returns nodes of the trie with the specified prefix path,
 // it will start iteration at the key after the given prefix path.
 func (t *Trie) PrefixIterator(prefix []byte) NodeIterator {
-	if t.prefix != nil {
-		prefix = append(t.prefix, prefix...)
-	}
-
 	return newPrefixIterator(t, prefix)
 }
 
@@ -128,10 +109,6 @@ func (t *Trie) Get(key []byte) []byte {
 // The value bytes must not be modified by the caller.
 // If a node was not found in the database, a MissingNodeError is returned.
 func (t *Trie) TryGet(key []byte) ([]byte, error) {
-	if t.prefix != nil {
-		key = append(t.prefix, key...)
-	}
-
 	key = keybytesToHex(key)
 	value, newroot, didResolve, err := t.tryGet(t.root, key, 0)
 	if err == nil && didResolve {
@@ -206,10 +183,6 @@ func (t *Trie) Update(key, value []byte) {
 //
 // If a node was not found in the database, a MissingNodeError is returned.
 func (t *Trie) TryUpdate(key, value []byte) error {
-	if t.prefix != nil {
-		key = append(t.prefix, key...)
-	}
-
 	k := keybytesToHex(key)
 	if len(value) != 0 {
 		_, n, err := t.insert(t.root, nil, k, valueNode(value))
@@ -335,10 +308,6 @@ func (t *Trie) Delete(key []byte) {
 // TryDelete removes any existing value for key from the trie
 // If a node was not found in the database, a MissingNodeError is returned.
 func (t *Trie) TryDelete(key []byte) error {
-	if t.prefix != nil {
-		key = append(t.prefix, key...)
-	}
-
 	k := keybytesToHex(key)
 	_, n, err := t.delete(t.root, nil, k)
 	if err != nil {


### PR DESCRIPTION
### Description

1. Refactored `dpos.verifySeal` function.
2. Added verify seal to `dpos.verifyHeader` and `dpos.VerifyHeaders`
3. Changed signature `InsertHeaderChain` for all related interface and implementation. Replace `[]*types.Header` to `types.HeaderInsertDataBatch`. Change related codes as necessary.
2. Updated `blockchain.InsertChain` code. `verifyHeader` called after the last block is inserted.