### PR TITLE
Light node/insert header chain

### DIFF
--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -255,9 +255,11 @@ func (c *Clique) VerifyHeader(chain consensus.ChainReader, header *types.Header,
 // VerifyHeaders is similar to VerifyHeader, but verifies a batch of headers. The
 // method returns a quit channel to abort the operations and a results channel to
 // retrieve the async verifications (the order is that of the input slice).
-func (c *Clique) VerifyHeaders(chain consensus.ChainReader, headers []*types.Header, validators []common.Address, seals []bool) (chan<- struct{}, <-chan error) {
+func (c *Clique) VerifyHeaders(chain consensus.ChainReader, data types.HeaderInsertDataBatch, seals []bool) (chan<- struct{}, <-chan error) {
 	abort := make(chan struct{})
-	results := make(chan error, len(headers))
+	results := make(chan error, len(data))
+
+	headers, _ := data.Split()
 
 	go func() {
 		for i, header := range headers {

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -255,7 +255,7 @@ func (c *Clique) VerifyHeader(chain consensus.ChainReader, header *types.Header,
 // VerifyHeaders is similar to VerifyHeader, but verifies a batch of headers. The
 // method returns a quit channel to abort the operations and a results channel to
 // retrieve the async verifications (the order is that of the input slice).
-func (c *Clique) VerifyHeaders(chain consensus.ChainReader, headers []*types.Header, seals []bool) (chan<- struct{}, <-chan error) {
+func (c *Clique) VerifyHeaders(chain consensus.ChainReader, headers []*types.Header, validators []common.Address, seals []bool) (chan<- struct{}, <-chan error) {
 	abort := make(chan struct{})
 	results := make(chan error, len(headers))
 

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -68,7 +68,7 @@ type Engine interface {
 	// concurrently. The method returns a quit channel to abort the operations and
 	// a results channel to retrieve the async verifications (the order is that of
 	// the input slice).
-	VerifyHeaders(chain ChainReader, headers []*types.Header, seals []bool) (chan<- struct{}, <-chan error)
+	VerifyHeaders(chain ChainReader, headers []*types.Header, validators []common.Address, seals []bool) (chan<- struct{}, <-chan error)
 
 	// VerifyUncles verifies that the given block's uncles conform to the consensus
 	// rules of a given engine.

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -68,7 +68,7 @@ type Engine interface {
 	// concurrently. The method returns a quit channel to abort the operations and
 	// a results channel to retrieve the async verifications (the order is that of
 	// the input slice).
-	VerifyHeaders(chain ChainReader, headers []*types.Header, validators []common.Address, seals []bool) (chan<- struct{}, <-chan error)
+	VerifyHeaders(chain ChainReader, data types.HeaderInsertDataBatch, seals []bool) (chan<- struct{}, <-chan error)
 
 	// VerifyUncles verifies that the given block's uncles conform to the consensus
 	// rules of a given engine.

--- a/consensus/dpos/api.go
+++ b/consensus/dpos/api.go
@@ -47,7 +47,7 @@ func (api *API) GetConfirmedBlockNumber() (*big.Int, error) {
 // GetValidators will return the validator list based on the block header provided
 func GetValidators(diskdb ethdb.Database, header *types.Header) ([]common.Address, error) {
 	// re-construct trieDB and get the epochTrie
-	epochTrie, err := types.NewFullDposDatabase(diskdb).OpenTrie(header.DposContext.EpochRoot)
+	epochTrie, err := types.NewFullDposDatabase(diskdb).OpenEpochTrie(header.DposContext.EpochRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to recover the epochTrie based on the root: %s", err.Error())
 	}
@@ -78,7 +78,7 @@ func IsValidator(diskdb ethdb.Database, header *types.Header, addr common.Addres
 // GetCandidates will return the candidates list based on the block header provided
 func GetCandidates(diskdb ethdb.Database, header *types.Header) ([]common.Address, error) {
 	// re-construct trieDB and get the candidateTrie
-	candidateTrie, err := types.NewFullDposDatabase(diskdb).OpenTrie(header.DposContext.CandidateRoot)
+	candidateTrie, err := types.NewFullDposDatabase(diskdb).OpenCandidateTrie(header.DposContext.CandidateRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to recover the candidateTrie based on the root: %s", err.Error())
 	}
@@ -109,7 +109,7 @@ func GetCandidateInfo(stateDb *state.StateDB, candidateAddress common.Address, h
 	candidateDeposit := GetCandidateDeposit(stateDb, candidateAddress)
 
 	// get the candidateTrie
-	delegateTrie, err := types.NewFullDposDatabase(diskdb).OpenTrie(header.DposContext.DelegateRoot)
+	delegateTrie, err := types.NewFullDposDatabase(diskdb).OpenDelegateTrie(header.DposContext.DelegateRoot)
 	if err != nil {
 		return common.BigInt0, common.BigInt0, 0, fmt.Errorf("failed to recover the candidateTrie based on the root: %s", err.Error())
 	}
@@ -122,7 +122,7 @@ func GetCandidateInfo(stateDb *state.StateDB, candidateAddress common.Address, h
 // getMinedBlocksCount will return the number of blocks mined by the validator within the current epoch
 func getMinedBlocksCount(diskdb ethdb.Database, header *types.Header, validatorAddress common.Address) (int64, error) {
 	// re-construct the minedCntTrie
-	minedCntTrie, err := types.NewFullDposDatabase(diskdb).OpenTrie(header.DposContext.MinedCntRoot)
+	minedCntTrie, err := types.NewFullDposDatabase(diskdb).OpenMinedCntTrie(header.DposContext.MinedCntRoot)
 	if err != nil {
 		return 0, fmt.Errorf("failed to recover the minedCntTrie based on the root: %s", err.Error())
 	}

--- a/consensus/dpos/api.go
+++ b/consensus/dpos/api.go
@@ -13,7 +13,6 @@ import (
 	"github.com/DxChainNetwork/godx/core/state"
 	"github.com/DxChainNetwork/godx/core/types"
 	"github.com/DxChainNetwork/godx/ethdb"
-	"github.com/DxChainNetwork/godx/trie"
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
@@ -48,8 +47,7 @@ func (api *API) GetConfirmedBlockNumber() (*big.Int, error) {
 // GetValidators will return the validator list based on the block header provided
 func GetValidators(diskdb ethdb.Database, header *types.Header) ([]common.Address, error) {
 	// re-construct trieDB and get the epochTrie
-	trieDb := trie.NewDatabase(diskdb)
-	epochTrie, err := types.NewEpochTrie(header.DposContext.EpochRoot, trieDb)
+	epochTrie, err := types.NewDposDb(diskdb).OpenTrie(header.DposContext.EpochRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to recover the epochTrie based on the root: %s", err.Error())
 	}
@@ -80,8 +78,7 @@ func IsValidator(diskdb ethdb.Database, header *types.Header, addr common.Addres
 // GetCandidates will return the candidates list based on the block header provided
 func GetCandidates(diskdb ethdb.Database, header *types.Header) ([]common.Address, error) {
 	// re-construct trieDB and get the candidateTrie
-	trieDb := trie.NewDatabase(diskdb)
-	candidateTrie, err := types.NewCandidateTrie(header.DposContext.CandidateRoot, trieDb)
+	candidateTrie, err := types.NewDposDb(diskdb).OpenTrie(header.DposContext.CandidateRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to recover the candidateTrie based on the root: %s", err.Error())
 	}
@@ -107,12 +104,12 @@ func GetValidatorInfo(stateDb *state.StateDB, validatorAddress common.Address, d
 }
 
 // GetCandidateInfo will return the detailed candidates information
-func GetCandidateInfo(stateDb *state.StateDB, candidateAddress common.Address, header *types.Header, trieDb *trie.Database) (common.BigInt, common.BigInt, uint64, error) {
+func GetCandidateInfo(stateDb *state.StateDB, candidateAddress common.Address, header *types.Header, diskdb ethdb.Database) (common.BigInt, common.BigInt, uint64, error) {
 	// get detailed candidates information
 	candidateDeposit := GetCandidateDeposit(stateDb, candidateAddress)
 
 	// get the candidateTrie
-	delegateTrie, err := types.NewDelegateTrie(header.DposContext.DelegateRoot, trieDb)
+	delegateTrie, err := types.NewDposDb(diskdb).OpenTrie(header.DposContext.DelegateRoot)
 	if err != nil {
 		return common.BigInt0, common.BigInt0, 0, fmt.Errorf("failed to recover the candidateTrie based on the root: %s", err.Error())
 	}
@@ -125,8 +122,7 @@ func GetCandidateInfo(stateDb *state.StateDB, candidateAddress common.Address, h
 // getMinedBlocksCount will return the number of blocks mined by the validator within the current epoch
 func getMinedBlocksCount(diskdb ethdb.Database, header *types.Header, validatorAddress common.Address) (int64, error) {
 	// re-construct the minedCntTrie
-	trieDb := trie.NewDatabase(diskdb)
-	minedCntTrie, err := types.NewMinedCntTrie(header.DposContext.MinedCntRoot, trieDb)
+	minedCntTrie, err := types.NewDposDb(diskdb).OpenTrie(header.DposContext.MinedCntRoot)
 	if err != nil {
 		return 0, fmt.Errorf("failed to recover the minedCntTrie based on the root: %s", err.Error())
 	}

--- a/consensus/dpos/api.go
+++ b/consensus/dpos/api.go
@@ -47,7 +47,7 @@ func (api *API) GetConfirmedBlockNumber() (*big.Int, error) {
 // GetValidators will return the validator list based on the block header provided
 func GetValidators(diskdb ethdb.Database, header *types.Header) ([]common.Address, error) {
 	// re-construct trieDB and get the epochTrie
-	epochTrie, err := types.NewDposDb(diskdb).OpenTrie(header.DposContext.EpochRoot)
+	epochTrie, err := types.NewFullDposDatabase(diskdb).OpenTrie(header.DposContext.EpochRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to recover the epochTrie based on the root: %s", err.Error())
 	}
@@ -78,7 +78,7 @@ func IsValidator(diskdb ethdb.Database, header *types.Header, addr common.Addres
 // GetCandidates will return the candidates list based on the block header provided
 func GetCandidates(diskdb ethdb.Database, header *types.Header) ([]common.Address, error) {
 	// re-construct trieDB and get the candidateTrie
-	candidateTrie, err := types.NewDposDb(diskdb).OpenTrie(header.DposContext.CandidateRoot)
+	candidateTrie, err := types.NewFullDposDatabase(diskdb).OpenTrie(header.DposContext.CandidateRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to recover the candidateTrie based on the root: %s", err.Error())
 	}
@@ -109,7 +109,7 @@ func GetCandidateInfo(stateDb *state.StateDB, candidateAddress common.Address, h
 	candidateDeposit := GetCandidateDeposit(stateDb, candidateAddress)
 
 	// get the candidateTrie
-	delegateTrie, err := types.NewDposDb(diskdb).OpenTrie(header.DposContext.DelegateRoot)
+	delegateTrie, err := types.NewFullDposDatabase(diskdb).OpenTrie(header.DposContext.DelegateRoot)
 	if err != nil {
 		return common.BigInt0, common.BigInt0, 0, fmt.Errorf("failed to recover the candidateTrie based on the root: %s", err.Error())
 	}
@@ -122,7 +122,7 @@ func GetCandidateInfo(stateDb *state.StateDB, candidateAddress common.Address, h
 // getMinedBlocksCount will return the number of blocks mined by the validator within the current epoch
 func getMinedBlocksCount(diskdb ethdb.Database, header *types.Header, validatorAddress common.Address) (int64, error) {
 	// re-construct the minedCntTrie
-	minedCntTrie, err := types.NewDposDb(diskdb).OpenTrie(header.DposContext.MinedCntRoot)
+	minedCntTrie, err := types.NewFullDposDatabase(diskdb).OpenTrie(header.DposContext.MinedCntRoot)
 	if err != nil {
 		return 0, fmt.Errorf("failed to recover the minedCntTrie based on the root: %s", err.Error())
 	}

--- a/consensus/dpos/candidate.go
+++ b/consensus/dpos/candidate.go
@@ -58,7 +58,7 @@ func CandidateTxDataValidation(state stateDB, data types.AddCandidateTxData, can
 // IsCandidate will check whether or not the given address is a candidate address
 func IsCandidate(candidateAddress common.Address, header *types.Header, diskDB ethdb.Database) bool {
 	// re-construct trieDB and get the candidateTrie
-	candidateTrie, err := types.NewDposDb(diskDB).OpenTrie(header.DposContext.CandidateRoot)
+	candidateTrie, err := types.NewFullDposDatabase(diskDB).OpenTrie(header.DposContext.CandidateRoot)
 	if err != nil {
 		return false
 	}

--- a/consensus/dpos/candidate.go
+++ b/consensus/dpos/candidate.go
@@ -58,8 +58,7 @@ func CandidateTxDataValidation(state stateDB, data types.AddCandidateTxData, can
 // IsCandidate will check whether or not the given address is a candidate address
 func IsCandidate(candidateAddress common.Address, header *types.Header, diskDB ethdb.Database) bool {
 	// re-construct trieDB and get the candidateTrie
-	trieDb := trie.NewDatabase(diskDB)
-	candidateTrie, err := types.NewCandidateTrie(header.DposContext.CandidateRoot, trieDb)
+	candidateTrie, err := types.NewDposDb(diskDB).OpenTrie(header.DposContext.CandidateRoot)
 	if err != nil {
 		return false
 	}

--- a/consensus/dpos/candidate.go
+++ b/consensus/dpos/candidate.go
@@ -66,7 +66,7 @@ func IsCandidate(candidateAddress common.Address, header *types.Header, diskDB e
 }
 
 // isCandidate determines whether the addr is a candidate from a candidateTrie
-func isCandidate(candidateTrie *trie.Trie, addr common.Address) bool {
+func isCandidate(candidateTrie types.DposTrie, addr common.Address) bool {
 	// check if the candidate exists
 	if value, err := candidateTrie.TryGet(addr.Bytes()); err != nil || value == nil {
 		return false
@@ -76,7 +76,7 @@ func isCandidate(candidateTrie *trie.Trie, addr common.Address) bool {
 
 // CalcCandidateTotalVotes calculate the total votes for the candidates. The result include the deposit for the
 // candidates himself and the delegated votes from delegator
-func CalcCandidateTotalVotes(candidateAddr common.Address, state stateDB, delegateTrie *trie.Trie) common.BigInt {
+func CalcCandidateTotalVotes(candidateAddr common.Address, state stateDB, delegateTrie types.DposTrie) common.BigInt {
 	// Calculate the candidates deposit and delegatedVote
 	candidateDeposit := GetCandidateDeposit(state, candidateAddr)
 	delegatedVote := calcCandidateDelegatedVotes(state, candidateAddr, delegateTrie)
@@ -85,7 +85,7 @@ func CalcCandidateTotalVotes(candidateAddr common.Address, state stateDB, delega
 }
 
 // calcCandidateDelegatedVotes calculate the total votes from delegator for the candidates in the current dposContext
-func calcCandidateDelegatedVotes(state stateDB, candidateAddr common.Address, dt *trie.Trie) common.BigInt {
+func calcCandidateDelegatedVotes(state stateDB, candidateAddr common.Address, dt types.DposTrie) common.BigInt {
 	delegateIterator := trie.NewIterator(dt.PrefixIterator(candidateAddr.Bytes()))
 	// loop through each delegator, get all votes
 	delegatorVotes := common.BigInt0

--- a/consensus/dpos/candidate.go
+++ b/consensus/dpos/candidate.go
@@ -58,7 +58,7 @@ func CandidateTxDataValidation(state stateDB, data types.AddCandidateTxData, can
 // IsCandidate will check whether or not the given address is a candidate address
 func IsCandidate(candidateAddress common.Address, header *types.Header, diskDB ethdb.Database) bool {
 	// re-construct trieDB and get the candidateTrie
-	candidateTrie, err := types.NewFullDposDatabase(diskDB).OpenTrie(header.DposContext.CandidateRoot)
+	candidateTrie, err := types.NewFullDposDatabase(diskDB).OpenCandidateTrie(header.DposContext.CandidateRoot)
 	if err != nil {
 		return false
 	}

--- a/consensus/dpos/delegator.go
+++ b/consensus/dpos/delegator.go
@@ -65,7 +65,7 @@ func VoteTxDepositValidation(state stateDB, delegatorAddress common.Address, vot
 // HasVoted will check whether the provided delegator address is voted
 func HasVoted(delegatorAddress common.Address, header *types.Header, diskDB ethdb.Database) bool {
 	// re-construct trieDB and get the voteTrie
-	voteTrie, err := types.NewDposDb(diskDB).OpenTrie(header.DposContext.VoteRoot)
+	voteTrie, err := types.NewFullDposDatabase(diskDB).OpenTrie(header.DposContext.VoteRoot)
 	if err != nil {
 		return false
 	}

--- a/consensus/dpos/delegator.go
+++ b/consensus/dpos/delegator.go
@@ -65,7 +65,7 @@ func VoteTxDepositValidation(state stateDB, delegatorAddress common.Address, vot
 // HasVoted will check whether the provided delegator address is voted
 func HasVoted(delegatorAddress common.Address, header *types.Header, diskDB ethdb.Database) bool {
 	// re-construct trieDB and get the voteTrie
-	voteTrie, err := types.NewFullDposDatabase(diskDB).OpenTrie(header.DposContext.VoteRoot)
+	voteTrie, err := types.NewFullDposDatabase(diskDB).OpenVoteTrie(header.DposContext.VoteRoot)
 	if err != nil {
 		return false
 	}

--- a/consensus/dpos/delegator.go
+++ b/consensus/dpos/delegator.go
@@ -8,7 +8,6 @@ import (
 	"github.com/DxChainNetwork/godx/common"
 	"github.com/DxChainNetwork/godx/core/types"
 	"github.com/DxChainNetwork/godx/ethdb"
-	"github.com/DxChainNetwork/godx/trie"
 )
 
 // ProcessVote process the process request for state and dpos context
@@ -66,8 +65,7 @@ func VoteTxDepositValidation(state stateDB, delegatorAddress common.Address, vot
 // HasVoted will check whether the provided delegator address is voted
 func HasVoted(delegatorAddress common.Address, header *types.Header, diskDB ethdb.Database) bool {
 	// re-construct trieDB and get the voteTrie
-	trieDb := trie.NewDatabase(diskDB)
-	voteTrie, err := types.NewVoteTrie(header.DposContext.VoteRoot, trieDb)
+	voteTrie, err := types.NewDposDb(diskDB).OpenTrie(header.DposContext.VoteRoot)
 	if err != nil {
 		return false
 	}

--- a/consensus/dpos/dpos.go
+++ b/consensus/dpos/dpos.go
@@ -250,7 +250,7 @@ func (d *Dpos) verifySeal(chain consensus.ChainReader, header *types.Header, par
 	} else {
 		parent = chain.GetHeader(header.ParentHash, number-1)
 	}
-	dposContext, err := types.NewDposContextFromProto(d.db, parent.DposContext)
+	dposContext, err := types.NewDposContextFromProto(types.NewDposDb(d.db), parent.DposContext)
 	if err != nil {
 		return err
 	}
@@ -361,7 +361,7 @@ func (d *Dpos) Prepare(chain consensus.ChainReader, header *types.Header) error 
 }
 
 // accumulateRewards add the block award to Coinbase of validator
-func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header *types.Header, db *trie.Database, genesis *types.Header) {
+func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header *types.Header, db ethdb.Database, genesis *types.Header) {
 	// Select the correct block reward based on chain progression
 	blockReward := frontierBlockReward
 	if config.IsByzantium(header.Number) {
@@ -383,7 +383,7 @@ func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header 
 
 	// Loop over the delegators to add delegator rewards
 	preEpochSnapshotDelegateTrieRoot := getPreEpochSnapshotDelegateTrieRoot(state, genesis)
-	delegateTrie, err := getPreEpochSnapshotDelegateTrie(db, preEpochSnapshotDelegateTrieRoot)
+	delegateTrie, err := getPreEpochSnapshotDelegateTrie(types.NewDposDb(db), preEpochSnapshotDelegateTrieRoot)
 	if err != nil {
 		log.Error("couldn't get snapshot delegate trie, error:", err)
 		return
@@ -409,7 +409,7 @@ func (d *Dpos) Finalize(chain consensus.ChainReader, header *types.Header, state
 	uncles []*types.Header, receipts []*types.Receipt, dposContext *types.DposContext) (*types.Block, error) {
 	// Accumulate block rewards and commit the final state root
 	genesis := chain.GetHeaderByNumber(0)
-	accumulateRewards(chain.Config(), state, header, trie.NewDatabase(d.db), genesis)
+	accumulateRewards(chain.Config(), state, header, d.db, genesis)
 
 	if d.Mode == ModeFake {
 		header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
@@ -465,7 +465,7 @@ func (d *Dpos) CheckValidator(lastBlock *types.Block, now int64) error {
 	if err := d.checkDeadline(lastBlock, now); err != nil {
 		return err
 	}
-	dposContext, err := types.NewDposContextFromProto(d.db, lastBlock.Header().DposContext)
+	dposContext, err := types.NewDposContextFromProto(types.NewDposDb(d.db), lastBlock.Header().DposContext)
 	if err != nil {
 		return err
 	}
@@ -602,8 +602,8 @@ func updateMinedCnt(parentBlockTime int64, validator common.Address, dposContext
 }
 
 // getPreEpochSnapshotDelegateTrie get the snapshot delegate trie of pre epoch
-func getPreEpochSnapshotDelegateTrie(db *trie.Database, root common.Hash) (*trie.Trie, error) {
-	return types.NewDelegateTrie(root, db)
+func getPreEpochSnapshotDelegateTrie(db types.DposDatabase, root common.Hash) (*trie.Trie, error) {
+	return db.OpenTrie(root)
 }
 
 func setMinedCnt(minedCntTrie *trie.Trie, epoch int64, validator common.Address, value uint64) error {

--- a/consensus/dpos/dpos.go
+++ b/consensus/dpos/dpos.go
@@ -250,7 +250,7 @@ func (d *Dpos) verifySeal(chain consensus.ChainReader, header *types.Header, par
 	} else {
 		parent = chain.GetHeader(header.ParentHash, number-1)
 	}
-	dposContext, err := types.NewDposContextFromProto(types.NewDposDb(d.db), parent.DposContext)
+	dposContext, err := types.NewDposContextFromProto(types.NewFullDposDatabase(d.db), parent.DposContext)
 	if err != nil {
 		return err
 	}
@@ -383,7 +383,7 @@ func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header 
 
 	// Loop over the delegators to add delegator rewards
 	preEpochSnapshotDelegateTrieRoot := getPreEpochSnapshotDelegateTrieRoot(state, genesis)
-	delegateTrie, err := getPreEpochSnapshotDelegateTrie(types.NewDposDb(db), preEpochSnapshotDelegateTrieRoot)
+	delegateTrie, err := getPreEpochSnapshotDelegateTrie(types.NewFullDposDatabase(db), preEpochSnapshotDelegateTrieRoot)
 	if err != nil {
 		log.Error("couldn't get snapshot delegate trie, error:", err)
 		return
@@ -465,7 +465,7 @@ func (d *Dpos) CheckValidator(lastBlock *types.Block, now int64) error {
 	if err := d.checkDeadline(lastBlock, now); err != nil {
 		return err
 	}
-	dposContext, err := types.NewDposContextFromProto(types.NewDposDb(d.db), lastBlock.Header().DposContext)
+	dposContext, err := types.NewDposContextFromProto(types.NewFullDposDatabase(d.db), lastBlock.Header().DposContext)
 	if err != nil {
 		return err
 	}
@@ -603,7 +603,7 @@ func updateMinedCnt(parentBlockTime int64, validator common.Address, dposContext
 
 // getPreEpochSnapshotDelegateTrie get the snapshot delegate trie of pre epoch
 func getPreEpochSnapshotDelegateTrie(db types.DposDatabase, root common.Hash) (*trie.Trie, error) {
-	return db.OpenTrie(root)
+	return db.OpenEpochTrie(root)
 }
 
 func setMinedCnt(minedCntTrie *trie.Trie, epoch int64, validator common.Address, value uint64) error {

--- a/consensus/dpos/dpos.go
+++ b/consensus/dpos/dpos.go
@@ -198,7 +198,7 @@ func (d *Dpos) verifyHeader(chain consensus.ChainReader, header *types.Header, v
 	}
 	var vGetter validatorHelper
 	if len(validators) != 0 {
-		vGetter = newVHelper(validators, header, d.db)
+		vGetter = newVHelper(validators, header)
 	} else {
 		vGetter = newDBVHelper(d.db, parent, header)
 	}
@@ -663,14 +663,12 @@ type validatorHelper interface {
 type vHelper struct {
 	validators []common.Address
 	header     *types.Header
-	db         ethdb.Database
 }
 
-func newVHelper(validators []common.Address, header *types.Header, db ethdb.Database) *vHelper {
+func newVHelper(validators []common.Address, header *types.Header) *vHelper {
 	return &vHelper{
 		validators: validators,
 		header:     header,
-		db:         db,
 	}
 }
 

--- a/consensus/dpos/dpos.go
+++ b/consensus/dpos/dpos.go
@@ -602,18 +602,18 @@ func updateMinedCnt(parentBlockTime int64, validator common.Address, dposContext
 }
 
 // getPreEpochSnapshotDelegateTrie get the snapshot delegate trie of pre epoch
-func getPreEpochSnapshotDelegateTrie(db types.DposDatabase, root common.Hash) (*trie.Trie, error) {
+func getPreEpochSnapshotDelegateTrie(db types.DposDatabase, root common.Hash) (types.DposTrie, error) {
 	return db.OpenLastDelegateTrie(root)
 }
 
-func setMinedCnt(minedCntTrie *trie.Trie, epoch int64, validator common.Address, value uint64) error {
+func setMinedCnt(minedCntTrie types.DposTrie, epoch int64, validator common.Address, value uint64) error {
 	keyBytes := makeMinedCntKey(epoch, validator)
 	valueBytes := common.Uint64ToByte(value)
 	return minedCntTrie.TryUpdate(keyBytes, valueBytes)
 }
 
 // getMinedCnt get the mined count of a specified validator in a certain epoch from the minedCntTrie
-func getMinedCnt(minedCntTrie *trie.Trie, epoch int64, validator common.Address) (uint64, error) {
+func getMinedCnt(minedCntTrie types.DposTrie, epoch int64, validator common.Address) (uint64, error) {
 	key := makeMinedCntKey(epoch, validator)
 	cntBytes, err := minedCntTrie.TryGet(key)
 	if err != nil {

--- a/consensus/dpos/dpos.go
+++ b/consensus/dpos/dpos.go
@@ -228,12 +228,12 @@ func (d *Dpos) VerifyHeaders(chain consensus.ChainReader, batch types.HeaderInse
 	go func() {
 		for i, header := range headers {
 			parents := headers[:i]
-			var validators []common.Address
-			if i != 0 {
-				validators = validatorsSet[i-1]
-			}
-			err := validateHeaderWithValidators(header)
+			err := validateHeaderWithValidators(header, validatorsSet[i])
 			if err != nil {
+				var validators []common.Address
+				if i != 0 {
+					validators = validatorsSet[i-1]
+				}
 				err = d.verifyHeader(chain, header, validators, parents, seals[i])
 			}
 			select {

--- a/consensus/dpos/dpos.go
+++ b/consensus/dpos/dpos.go
@@ -603,7 +603,7 @@ func updateMinedCnt(parentBlockTime int64, validator common.Address, dposContext
 
 // getPreEpochSnapshotDelegateTrie get the snapshot delegate trie of pre epoch
 func getPreEpochSnapshotDelegateTrie(db types.DposDatabase, root common.Hash) (*trie.Trie, error) {
-	return db.OpenEpochTrie(root)
+	return db.OpenLastDelegateTrie(root)
 }
 
 func setMinedCnt(minedCntTrie *trie.Trie, epoch int64, validator common.Address, value uint64) error {

--- a/consensus/dpos/dpos.go
+++ b/consensus/dpos/dpos.go
@@ -233,11 +233,6 @@ func (d *Dpos) VerifyHeaders(chain consensus.ChainReader, data types.HeaderInser
 				validators = validatorsSet[i-1]
 			}
 			err := d.verifyHeader(chain, header, validators, parents, seals[i])
-
-			// If validators have been changed, save the validators
-			if err == nil && (i == 0 || IsElectBlock(parents[i-1], header)) {
-				err = types.SaveValidators(validatorsSet[i], d.db)
-			}
 			select {
 			case <-abort:
 				return

--- a/consensus/dpos/dpos.go
+++ b/consensus/dpos/dpos.go
@@ -671,7 +671,6 @@ func makeMinedCntKey(epoch int64, addr common.Address) []byte {
 // and save the validators to db
 type validatorHelper interface {
 	getValidator() (common.Address, error)
-	saveValidators() error
 }
 
 // vHelper is the validatorHelper which gets info from validators
@@ -691,10 +690,6 @@ func newVHelper(validators []common.Address, header *types.Header, db ethdb.Data
 
 func (g *vHelper) getValidator() (common.Address, error) {
 	return lookupValidator(g.header.Time.Int64(), g.validators)
-}
-
-func (g *vHelper) saveValidators() error {
-	return types.SaveValidators(g.validators, g.db)
 }
 
 // dbVHelper get the validator for the header from database
@@ -733,14 +728,6 @@ func (g *dbVHelper) getValidator() (common.Address, error) {
 	}
 	g.validators = validators
 	return lookupValidator(g.header.Time.Int64(), validators)
-}
-
-func (g *dbVHelper) saveValidators() error {
-	validators, err := g.getValidators()
-	if err != nil {
-		return err
-	}
-	return types.SaveValidators(validators, g.db)
 }
 
 func (g *dbVHelper) getValidators() ([]common.Address, error) {

--- a/consensus/dpos/dpos_integration_test.go
+++ b/consensus/dpos/dpos_integration_test.go
@@ -1388,7 +1388,7 @@ func (g *genesisConfig) toBlock(db ethdb.Database) *types.Block {
 
 // dposContextWithGenesis parse the genesis to dposContext
 func dposContextWithGenesis(statedb *state.StateDB, g *genesisConfig, db ethdb.Database) (*types.DposContext, error) {
-	dc, err := types.NewDposContextFromProto(types.NewDposDb(db), &types.DposContextRoot{})
+	dc, err := types.NewDposContextFromProto(types.NewFullDposDatabase(db), &types.DposContextRoot{})
 	if err != nil {
 		return nil, err
 	}

--- a/consensus/dpos/dpos_integration_test.go
+++ b/consensus/dpos/dpos_integration_test.go
@@ -1291,7 +1291,7 @@ func forEachDelegatorForCandidate(ctx *types.DposContext, candidate common.Addre
 
 // forEachDelegatorForCandidateFromTrie iterate over the delegator votes for the candidate and execute
 //// the cb callback function
-func forEachDelegatorForCandidateFromTrie(delegateTrie *trie.Trie, candidate common.Address, cb func(delegator common.Address) error) error {
+func forEachDelegatorForCandidateFromTrie(delegateTrie types.DposTrie, candidate common.Address, cb func(delegator common.Address) error) error {
 	delegatorIterator := trie.NewIterator(delegateTrie.PrefixIterator(candidate.Bytes()))
 	var hasEntry bool
 	for delegatorIterator.Next() {

--- a/consensus/dpos/dpos_integration_test.go
+++ b/consensus/dpos/dpos_integration_test.go
@@ -1388,7 +1388,7 @@ func (g *genesisConfig) toBlock(db ethdb.Database) *types.Block {
 
 // dposContextWithGenesis parse the genesis to dposContext
 func dposContextWithGenesis(statedb *state.StateDB, g *genesisConfig, db ethdb.Database) (*types.DposContext, error) {
-	dc, err := types.NewDposContextFromProto(db, &types.DposContextRoot{})
+	dc, err := types.NewDposContextFromProto(types.NewDposDb(db), &types.DposContextRoot{})
 	if err != nil {
 		return nil, err
 	}

--- a/consensus/dpos/dpos_test.go
+++ b/consensus/dpos/dpos_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/DxChainNetwork/godx/ethdb"
 	"github.com/DxChainNetwork/godx/params"
 	"github.com/DxChainNetwork/godx/rlp"
-	"github.com/DxChainNetwork/godx/trie"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -558,7 +557,7 @@ func mockDposContext(db ethdb.Database, now int64, delegator common.Address) (*t
 	return dposContext, candidates, nil
 }
 
-func setMinedCntTrie(epochID int64, candidate common.Address, minedCntTrie *trie.Trie, count int64) error {
+func setMinedCntTrie(epochID int64, candidate common.Address, minedCntTrie types.DposTrie, count int64) error {
 	key := make([]byte, 8)
 	binary.BigEndian.PutUint64(key, uint64(epochID))
 	cntBytes := make([]byte, 8)

--- a/consensus/dpos/dpos_test.go
+++ b/consensus/dpos/dpos_test.go
@@ -142,7 +142,7 @@ func TestAccumulateRewards(t *testing.T) {
 	expectedValidatorReward := big.NewInt(1.5e+18)
 
 	// allocate the block reward among validator and its delegators
-	accumulateRewards(params.MainnetChainConfig, stateDB, header, trie.NewDatabase(db), testChain.GetHeaderByNumber(0))
+	accumulateRewards(params.MainnetChainConfig, stateDB, header, db, testChain.GetHeaderByNumber(0))
 	header.Root = stateDB.IntermediateRoot(params.MainnetChainConfig.IsEIP158(header.Number))
 
 	validatorBalance := stateDB.GetBalance(validator)
@@ -157,7 +157,7 @@ func TestAccumulateRewards(t *testing.T) {
 
 	// mock block sync
 	headerCopy := header
-	accumulateRewards(params.MainnetChainConfig, stateDbCopy, headerCopy, trie.NewDatabase(db), testChain.GetHeaderByNumber(0))
+	accumulateRewards(params.MainnetChainConfig, stateDbCopy, headerCopy, db, testChain.GetHeaderByNumber(0))
 	headerCopy.Root = stateDB.IntermediateRoot(params.MainnetChainConfig.IsEIP158(headerCopy.Number))
 
 	if header.Root != headerCopy.Root {
@@ -490,7 +490,7 @@ func (test testChainReader) insert(hash common.Hash, number uint64, time uint64,
 }
 
 func mockDposContext(db ethdb.Database, now int64, delegator common.Address) (*types.DposContext, []common.Address, error) {
-	dposContext, err := types.NewDposContextFromProto(db, &types.DposContextRoot{})
+	dposContext, err := types.NewDposContextFromProto(types.NewDposDb(db), &types.DposContextRoot{})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/consensus/dpos/dpos_test.go
+++ b/consensus/dpos/dpos_test.go
@@ -490,7 +490,7 @@ func (test testChainReader) insert(hash common.Hash, number uint64, time uint64,
 }
 
 func mockDposContext(db ethdb.Database, now int64, delegator common.Address) (*types.DposContext, []common.Address, error) {
-	dposContext, err := types.NewDposContextFromProto(types.NewDposDb(db), &types.DposContextRoot{})
+	dposContext, err := types.NewDposContextFromProto(types.NewFullDposDatabase(db), &types.DposContextRoot{})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/consensus/dpos/epoch_context.go
+++ b/consensus/dpos/epoch_context.go
@@ -226,13 +226,15 @@ func allDelegatorForValidators(ctx *types.DposContext, validators []common.Addre
 // lookupValidator returns the validator responsible for producing the block in the curTime.
 // If not a valid timestamp, an error is returned
 func (ec *EpochContext) lookupValidator(blockTime int64) (validator common.Address, err error) {
-	validator = common.Address{}
-	slot, err := calcBlockSlot(blockTime)
+	validators, err := ec.DposContext.GetValidators()
 	if err != nil {
 		return common.Address{}, err
 	}
-	// Get validators and the expected validator
-	validators, err := ec.DposContext.GetValidators()
+	return lookupValidator(blockTime, validators)
+}
+
+func lookupValidator(blockTime int64, validators []common.Address) (validator common.Address, err error) {
+	slot, err := calcBlockSlot(blockTime)
 	if err != nil {
 		return common.Address{}, err
 	}

--- a/consensus/dpos/epoch_context.go
+++ b/consensus/dpos/epoch_context.go
@@ -70,7 +70,7 @@ func (ec *EpochContext) tryElect(genesis, parent *types.Header) error {
 			return err
 		}
 		// Set the new validators
-		epochTrie, _ := ec.DposContext.DB().OpenTrie(common.Hash{})
+		epochTrie, _ := ec.DposContext.DB().OpenEpochTrie(common.Hash{})
 		ec.DposContext.SetEpoch(epochTrie)
 		err = ec.DposContext.SetValidators(validators)
 		if err != nil {

--- a/consensus/dpos/epoch_context.go
+++ b/consensus/dpos/epoch_context.go
@@ -70,7 +70,7 @@ func (ec *EpochContext) tryElect(genesis, parent *types.Header) error {
 			return err
 		}
 		// Set the new validators
-		epochTrie, _ := types.NewEpochTrie(common.Hash{}, ec.DposContext.DB())
+		epochTrie, _ := ec.DposContext.DB().OpenTrie(common.Hash{})
 		ec.DposContext.SetEpoch(epochTrie)
 		err = ec.DposContext.SetValidators(validators)
 		if err != nil {

--- a/consensus/dpos/epoch_context_test.go
+++ b/consensus/dpos/epoch_context_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestLookupValidator(t *testing.T) {
 	db := ethdb.NewMemDatabase()
-	dposCtx, _ := types.NewDposContext(db)
+	dposCtx, _ := types.NewDposContext(types.NewDposDb(db))
 	mockEpochContext := &EpochContext{
 		DposContext: dposCtx,
 	}
@@ -73,7 +73,7 @@ func Test_CountVotes(t *testing.T) {
 	stateDB, _ = state.New(root, sdb)
 
 	// create epoch context
-	dposCtx, _ := types.NewDposContext(db)
+	dposCtx, _ := types.NewDposContext(types.NewDposDb(db))
 	epochContext := &EpochContext{
 		DposContext: dposCtx,
 		stateDB:     stateDB,

--- a/consensus/dpos/epoch_context_test.go
+++ b/consensus/dpos/epoch_context_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestLookupValidator(t *testing.T) {
 	db := ethdb.NewMemDatabase()
-	dposCtx, _ := types.NewDposContext(types.NewDposDb(db))
+	dposCtx, _ := types.NewDposContext(types.NewFullDposDatabase(db))
 	mockEpochContext := &EpochContext{
 		DposContext: dposCtx,
 	}
@@ -73,7 +73,7 @@ func Test_CountVotes(t *testing.T) {
 	stateDB, _ = state.New(root, sdb)
 
 	// create epoch context
-	dposCtx, _ := types.NewDposContext(types.NewDposDb(db))
+	dposCtx, _ := types.NewDposContext(types.NewFullDposDatabase(db))
 	epochContext := &EpochContext{
 		DposContext: dposCtx,
 		stateDB:     stateDB,

--- a/consensus/dpos/epoch_context_test.go
+++ b/consensus/dpos/epoch_context_test.go
@@ -170,18 +170,27 @@ func Test_KickoutValidators(t *testing.T) {
 	}
 
 	for i := 0; i < MaxValidatorSize/3; i++ {
-		canFromTrie := epochContext.DposContext.CandidateTrie().Get(candidates[i].Bytes())
+		canFromTrie, err := epochContext.DposContext.CandidateTrie().TryGet(candidates[i].Bytes())
+		if err != nil {
+			t.Errorf("failed to get from candidate trie: %v", err)
+		}
 		if canFromTrie != nil {
 			t.Errorf("failed to delete the kick out one from candidates trie: %s", candidates[i].String())
 		}
 
-		delegatorFromTrie := epochContext.DposContext.DelegateTrie().Get(append(candidates[i].Bytes(), delegator.Bytes()...))
+		delegatorFromTrie, err := epochContext.DposContext.DelegateTrie().TryGet(append(candidates[i].Bytes(), delegator.Bytes()...))
+		if err != nil {
+			t.Errorf("failed to get from delegate trie: %v", err)
+		}
 		if delegatorFromTrie != nil {
 			t.Errorf("failed to delete the kick out one from delegate trie: %s", candidates[i].String())
 		}
 	}
 
-	votedFromTrie := epochContext.DposContext.VoteTrie().Get(delegator.Bytes())
+	votedFromTrie, err := epochContext.DposContext.VoteTrie().TryGet(delegator.Bytes())
+	if err != nil {
+		t.Errorf("failed to get from vote trie: %v", err)
+	}
 	if votedFromTrie == nil {
 		t.Fatalf("failed to retrieve voted candidates")
 	}

--- a/consensus/dpos/state_test.go
+++ b/consensus/dpos/state_test.go
@@ -36,7 +36,7 @@ func newStateAndDposContext() (*state.StateDB, *types.DposContext, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	ctx, err := types.NewDposContext(db)
+	ctx, err := types.NewDposContext(types.NewDposDb(db))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/consensus/dpos/state_test.go
+++ b/consensus/dpos/state_test.go
@@ -36,7 +36,7 @@ func newStateAndDposContext() (*state.StateDB, *types.DposContext, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	ctx, err := types.NewDposContext(types.NewDposDb(db))
+	ctx, err := types.NewDposContext(types.NewFullDposDatabase(db))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -108,8 +108,9 @@ func (ethash *Ethash) VerifyHeader(chain consensus.ChainReader, header *types.He
 // VerifyHeaders is similar to VerifyHeader, but verifies a batch of headers
 // concurrently. The method returns a quit channel to abort the operations and
 // a results channel to retrieve the async verifications.
-func (ethash *Ethash) VerifyHeaders(chain consensus.ChainReader, headers []*types.Header, validators []common.Address, seals []bool) (chan<- struct{}, <-chan error) {
+func (ethash *Ethash) VerifyHeaders(chain consensus.ChainReader, data types.HeaderInsertDataBatch, seals []bool) (chan<- struct{}, <-chan error) {
 	// If we're running a full engine faking, accept any input as valid
+	headers, _ := data.Split()
 	if ethash.config.PowMode == ModeFullFake || len(headers) == 0 {
 		abort, results := make(chan struct{}), make(chan error, len(headers))
 		for i := 0; i < len(headers); i++ {

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -108,7 +108,7 @@ func (ethash *Ethash) VerifyHeader(chain consensus.ChainReader, header *types.He
 // VerifyHeaders is similar to VerifyHeader, but verifies a batch of headers
 // concurrently. The method returns a quit channel to abort the operations and
 // a results channel to retrieve the async verifications.
-func (ethash *Ethash) VerifyHeaders(chain consensus.ChainReader, headers []*types.Header, seals []bool) (chan<- struct{}, <-chan error) {
+func (ethash *Ethash) VerifyHeaders(chain consensus.ChainReader, headers []*types.Header, validators []common.Address, seals []bool) (chan<- struct{}, <-chan error) {
 	// If we're running a full engine faking, accept any input as valid
 	if ethash.config.PowMode == ModeFullFake || len(headers) == 0 {
 		abort, results := make(chan struct{}), make(chan error, len(headers))

--- a/core/block_validator_test.go
+++ b/core/block_validator_test.go
@@ -66,7 +66,7 @@ func TestHeaderVerification(t *testing.T) {
 				_, results = engine.VerifyHeaders(chain, []*types.Header{headers[i]}, []bool{true})
 			} else {
 				engine := ethash.NewFakeFailer(headers[i].Number.Uint64())
-				_, results = engine.VerifyHeaders(chain, []*types.Header{headers[i]}, []bool{true})
+				_, results = engine.VerifyHeaders(chain, []*types.Header{headers[i]}, nil, []bool{true})
 			}
 			// Wait for the verification result
 			select {
@@ -122,7 +122,7 @@ func testHeaderConcurrentVerification(t *testing.T, threads int) {
 
 		if valid {
 			chain, _ := NewBlockChain(testdb, nil, params.DposChainConfig, dpos.NewDposFaker(), vm.Config{}, nil)
-			_, results = chain.engine.VerifyHeaders(chain, headers, seals)
+			_, results = chain.engine.VerifyHeaders(chain, headers, nil, seals)
 			chain.Stop()
 		}
 
@@ -188,7 +188,7 @@ func testHeaderConcurrentAbortion(t *testing.T, threads int) {
 	chain, _ := NewBlockChain(testdb, nil, params.DposChainConfig, dpos.NewDposFaker(), vm.Config{}, nil)
 	defer chain.Stop()
 
-	abort, results := chain.engine.VerifyHeaders(chain, headers, seals)
+	abort, results := chain.engine.VerifyHeaders(chain, headers, nil, seals)
 	close(abort)
 
 	// Deplete the results channel

--- a/core/block_validator_test.go
+++ b/core/block_validator_test.go
@@ -63,7 +63,7 @@ func TestHeaderVerification(t *testing.T) {
 
 			if valid {
 				engine := dpos.NewDposFaker()
-				_, results = engine.VerifyHeaders(chain, []*types.Header{headers[i]}, []bool{true})
+				_, results = engine.VerifyHeaders(chain, []*types.Header{headers[i]}, nil, []bool{true})
 			} else {
 				engine := ethash.NewFakeFailer(headers[i].Number.Uint64())
 				_, results = engine.VerifyHeaders(chain, []*types.Header{headers[i]}, nil, []bool{true})
@@ -122,7 +122,8 @@ func testHeaderConcurrentVerification(t *testing.T, threads int) {
 
 		if valid {
 			chain, _ := NewBlockChain(testdb, nil, params.DposChainConfig, dpos.NewDposFaker(), vm.Config{}, nil)
-			_, results = chain.engine.VerifyHeaders(chain, headers, nil, seals)
+			data := types.NewHeaderInsertDataBatch(headers, nil)
+			_, results = chain.engine.VerifyHeaders(chain, data, seals)
 			chain.Stop()
 		}
 
@@ -188,7 +189,8 @@ func testHeaderConcurrentAbortion(t *testing.T, threads int) {
 	chain, _ := NewBlockChain(testdb, nil, params.DposChainConfig, dpos.NewDposFaker(), vm.Config{}, nil)
 	defer chain.Stop()
 
-	abort, results := chain.engine.VerifyHeaders(chain, headers, nil, seals)
+	data := types.NewHeaderInsertDataBatch(headers, nil)
+	abort, results := chain.engine.VerifyHeaders(chain, data, seals)
 	close(abort)
 
 	// Deplete the results channel

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -412,7 +412,7 @@ func (bc *BlockChain) DposCtx() (*types.DposContext, error) {
 
 // DposCtxAt returns a dposCtx based on a particular point in time.
 func (bc *BlockChain) DposCtxAt(root *types.DposContextRoot) (*types.DposContext, error) {
-	return types.NewDposContextFromProto(types.NewDposDb(bc.db), root)
+	return types.NewDposContextFromProto(types.NewFullDposDatabase(bc.db), root)
 }
 
 // StateCache returns the caching database underpinning the blockchain instance.
@@ -1227,7 +1227,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 		}
 
 		// construct dpos context from parent's dpos context root
-		dposCtx, err := types.NewDposContextFromProto(types.NewDposDb(bc.db), parent.Header().DposContext)
+		dposCtx, err := types.NewDposContextFromProto(types.NewFullDposDatabase(bc.db), parent.Header().DposContext)
 		if err != nil {
 			return it.index, events, coalescedLogs, err
 		}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1656,9 +1656,9 @@ Error: %v
 // should be done or not. The reason behind the optional check is because some
 // of the header retrieval mechanisms already need to verify nonces, as well as
 // because nonces can be verified sparsely, not needing to check each.
-func (bc *BlockChain) InsertHeaderChain(chain []*types.Header, checkFreq int) (int, error) {
+func (bc *BlockChain) InsertHeaderChain(data types.HeaderInsertDataBatch, checkFreq int) (int, error) {
 	start := time.Now()
-	if i, err := bc.hc.ValidateHeaderChain(chain, checkFreq); err != nil {
+	if i, err := bc.hc.ValidateHeaderChain(data, checkFreq); err != nil {
 		return i, err
 	}
 
@@ -1669,15 +1669,18 @@ func (bc *BlockChain) InsertHeaderChain(chain []*types.Header, checkFreq int) (i
 	bc.wg.Add(1)
 	defer bc.wg.Done()
 
-	whFunc := func(header *types.Header) error {
+	whFunc := func(data types.HeaderInsertData) error {
 		bc.mu.Lock()
 		defer bc.mu.Unlock()
 
-		_, err := bc.hc.WriteHeader(header)
-		return err
+		_, err := bc.hc.WriteHeader(data.Header)
+		if err != nil {
+			return err
+		}
+		return bc.writeValidators(data.Validators)
 	}
 
-	return bc.hc.InsertHeaderChain(chain, whFunc, start)
+	return bc.hc.InsertHeaderChain(data, whFunc, start)
 }
 
 // writeHeader writes a header into the local chain, given that its parent is
@@ -1698,6 +1701,11 @@ func (bc *BlockChain) writeHeader(header *types.Header) error {
 
 	_, err := bc.hc.WriteHeader(header)
 	return err
+}
+
+// WriteValidators write validators to the underlying database
+func (bc *BlockChain) writeValidators(validators []common.Address) error {
+	return types.SaveValidators(validators, bc.db)
 }
 
 // CurrentHeader retrieves the current head header of the canonical chain. The

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -412,7 +412,7 @@ func (bc *BlockChain) DposCtx() (*types.DposContext, error) {
 
 // DposCtxAt returns a dposCtx based on a particular point in time.
 func (bc *BlockChain) DposCtxAt(root *types.DposContextRoot) (*types.DposContext, error) {
-	return types.NewDposContextFromProto(bc.db, root)
+	return types.NewDposContextFromProto(types.NewDposDb(bc.db), root)
 }
 
 // StateCache returns the caching database underpinning the blockchain instance.
@@ -1227,7 +1227,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 		}
 
 		// construct dpos context from parent's dpos context root
-		dposCtx, err := types.NewDposContextFromProto(bc.db, parent.Header().DposContext)
+		dposCtx, err := types.NewDposContextFromProto(types.NewDposDb(bc.db), parent.Header().DposContext)
 		if err != nil {
 			return it.index, events, coalescedLogs, err
 		}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1160,11 +1160,9 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 		headers[i] = block.Header()
 		seals[i] = verifySeals
 	}
-	abort, results := bc.engine.VerifyHeaders(bc, headers, nil, seals)
-	defer close(abort)
 
 	// Peek the error for the first block to decide the directing import logic
-	it := newInsertIterator(chain, results, bc.Validator())
+	it := newInsertIterator(bc, chain, bc.Validator(), bc.engine)
 
 	block, err := it.next()
 	switch {
@@ -1202,7 +1200,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 
 	// Some other error occurred, abort
 	case err != nil:
-		stats.ignored += len(it.chain)
+		stats.ignored += len(it.blocks)
 		bc.reportBlock(block, nil, err)
 		return it.index, events, coalescedLogs, err
 	}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1160,7 +1160,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 		headers[i] = block.Header()
 		seals[i] = verifySeals
 	}
-	abort, results := bc.engine.VerifyHeaders(bc, headers, seals)
+	abort, results := bc.engine.VerifyHeaders(bc, headers, nil, seals)
 	defer close(abort)
 
 	// Peek the error for the first block to decide the directing import logic

--- a/core/blockchain_insert.go
+++ b/core/blockchain_insert.go
@@ -19,6 +19,8 @@ package core
 import (
 	"time"
 
+	"github.com/DxChainNetwork/godx/consensus"
+
 	"github.com/DxChainNetwork/godx/common"
 	"github.com/DxChainNetwork/godx/common/mclock"
 	"github.com/DxChainNetwork/godx/core/types"
@@ -80,43 +82,45 @@ func (st *insertStats) report(chain []*types.Block, index int, cache common.Stor
 
 // insertIterator is a helper to assist during chain import.
 type insertIterator struct {
-	chain     types.Blocks
-	results   <-chan error
+	chain     consensus.ChainReader
+	blocks    types.Blocks
 	index     int
 	validator Validator
+	engine    consensus.Engine
 }
 
 // newInsertIterator creates a new iterator based on the given blocks, which are
 // assumed to be a contiguous chain.
-func newInsertIterator(chain types.Blocks, results <-chan error, validator Validator) *insertIterator {
+func newInsertIterator(chain consensus.ChainReader, blocks types.Blocks, validator Validator, engine consensus.Engine) *insertIterator {
 	return &insertIterator{
 		chain:     chain,
-		results:   results,
+		blocks:    blocks,
 		index:     -1,
 		validator: validator,
+		engine:    engine,
 	}
 }
 
 // next returns the next block in the iterator, along with any potential validation
 // error for that block. When the end is reached, it will return (nil, nil).
 func (it *insertIterator) next() (*types.Block, error) {
-	if it.index+1 >= len(it.chain) {
-		it.index = len(it.chain)
+	if it.index+1 >= len(it.blocks) {
+		it.index = len(it.blocks)
 		return nil, nil
 	}
 	it.index++
-	if err := <-it.results; err != nil {
-		return it.chain[it.index], err
+	if err := it.engine.VerifyHeader(it.chain, it.blocks[it.index].Header(), true); err != nil {
+		return it.blocks[it.index], err
 	}
-	return it.chain[it.index], it.validator.ValidateBody(it.chain[it.index])
+	return it.blocks[it.index], it.validator.ValidateBody(it.blocks[it.index])
 }
 
 // current returns the current block that's being processed.
 func (it *insertIterator) current() *types.Block {
-	if it.index < 0 || it.index+1 >= len(it.chain) {
+	if it.index < 0 || it.index+1 >= len(it.blocks) {
 		return nil
 	}
-	return it.chain[it.index]
+	return it.blocks[it.index]
 }
 
 // previous returns the previous block was being processed, or nil
@@ -124,17 +128,17 @@ func (it *insertIterator) previous() *types.Block {
 	if it.index < 1 {
 		return nil
 	}
-	return it.chain[it.index-1]
+	return it.blocks[it.index-1]
 }
 
 // first returns the first block in the it.
 func (it *insertIterator) first() *types.Block {
-	return it.chain[0]
+	return it.blocks[0]
 }
 
 // remaining returns the number of remaining blocks.
 func (it *insertIterator) remaining() int {
-	return len(it.chain) - it.index
+	return len(it.blocks) - it.index
 }
 
 // processed returns the number of processed blocks.

--- a/core/chain_indexer_test.go
+++ b/core/chain_indexer_test.go
@@ -50,7 +50,7 @@ func TestChainIndexerWithChildren(t *testing.T) {
 // are randomized.
 func testChainIndexer(t *testing.T, count int) {
 	db := ethdb.NewMemDatabase()
-	dposCtx, err := types.NewDposContext(db)
+	dposCtx, err := types.NewDposContext(types.NewDposDb(db))
 	if err != nil {
 		t.Fatalf("falied to new dpos context: %v", err)
 	}

--- a/core/chain_indexer_test.go
+++ b/core/chain_indexer_test.go
@@ -50,7 +50,7 @@ func TestChainIndexerWithChildren(t *testing.T) {
 // are randomized.
 func testChainIndexer(t *testing.T, count int) {
 	db := ethdb.NewMemDatabase()
-	dposCtx, err := types.NewDposContext(types.NewDposDb(db))
+	dposCtx, err := types.NewDposContext(types.NewFullDposDatabase(db))
 	if err != nil {
 		t.Fatalf("falied to new dpos context: %v", err)
 	}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -441,7 +441,7 @@ func decodePrealloc(data string) GenesisAlloc {
 
 // initGenesisDposContext returns the dpos context of given genesis block
 func initGenesisDposContext(stateDB *state.StateDB, g *Genesis, db ethdb.Database) (*types.DposContext, error) {
-	dc, err := types.NewDposContextFromProto(types.NewDposDb(db), &types.DposContextRoot{})
+	dc, err := types.NewDposContextFromProto(types.NewFullDposDatabase(db), &types.DposContextRoot{})
 	if err != nil {
 		return nil, err
 	}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -441,7 +441,7 @@ func decodePrealloc(data string) GenesisAlloc {
 
 // initGenesisDposContext returns the dpos context of given genesis block
 func initGenesisDposContext(stateDB *state.StateDB, g *Genesis, db ethdb.Database) (*types.DposContext, error) {
-	dc, err := types.NewDposContextFromProto(db, &types.DposContextRoot{})
+	dc, err := types.NewDposContextFromProto(types.NewDposDb(db), &types.DposContextRoot{})
 	if err != nil {
 		return nil, err
 	}

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -41,7 +41,7 @@ func TestDefaultGenesisBlock(t *testing.T) {
 
 func TestSetupGenesis(t *testing.T) {
 	var (
-		customghash = common.HexToHash("0x796c3d4be7f1958e8dff2428b4c21b277ca890c606b1fdc4f43e950154ed7eff")
+		customghash = common.HexToHash("0xbfcc983a9994ac4aab200b4e7db90ac26842ee059d60c83462dd7a9a3cce10fc")
 		customg     = Genesis{
 			Config: params.DposChainConfig,
 			Alloc: MakeAlloc(

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -228,7 +228,8 @@ func (hc *HeaderChain) ValidateHeaderChain(chain []*types.Header, checkFreq int)
 	}
 	seals[len(seals)-1] = true // Last should always be verified to avoid junk
 
-	abort, results := hc.engine.VerifyHeaders(hc, chain, nil, seals)
+	data := types.NewHeaderInsertDataBatch(chain, nil)
+	abort, results := hc.engine.VerifyHeaders(hc, data, seals)
 	defer close(abort)
 
 	// Iterate over the headers and ensure they all check out

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -228,7 +228,7 @@ func (hc *HeaderChain) ValidateHeaderChain(chain []*types.Header, checkFreq int)
 	}
 	seals[len(seals)-1] = true // Last should always be verified to avoid junk
 
-	abort, results := hc.engine.VerifyHeaders(hc, chain, seals)
+	abort, results := hc.engine.VerifyHeaders(hc, chain, nil, seals)
 	defer close(abort)
 
 	// Iterate over the headers and ensure they all check out

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -197,14 +197,20 @@ func (hc *HeaderChain) WriteHeader(header *types.Header) (status WriteStatus, er
 	return
 }
 
+// WriteValidators write validators to the underlying database
+func (hc *HeaderChain) WriteValidators(validators []common.Address) error {
+	return types.SaveValidators(validators, hc.chainDb)
+}
+
 // WhCallback is a callback function for inserting individual headers.
 // A callback is used for two reasons: first, in a LightChain, status should be
 // processed and light chain events sent, while in a BlockChain this is not
 // necessary since chain events are sent after inserting blocks. Second, the
 // header writes should be protected by the parent chain mutex individually.
-type WhCallback func(*types.Header) error
+type WhCallback func(data types.HeaderInsertData) error
 
-func (hc *HeaderChain) ValidateHeaderChain(chain []*types.Header, checkFreq int) (int, error) {
+func (hc *HeaderChain) ValidateHeaderChain(data types.HeaderInsertDataBatch, checkFreq int) (int, error) {
+	chain, _ := data.Split()
 	// Do a sanity check that the provided chain is actually ordered and linked
 	for i := 1; i < len(chain); i++ {
 		if chain[i].Number.Uint64() != chain[i-1].Number.Uint64()+1 || chain[i].ParentHash != chain[i-1].Hash() {
@@ -228,7 +234,6 @@ func (hc *HeaderChain) ValidateHeaderChain(chain []*types.Header, checkFreq int)
 	}
 	seals[len(seals)-1] = true // Last should always be verified to avoid junk
 
-	data := types.NewHeaderInsertDataBatch(chain, nil)
 	abort, results := hc.engine.VerifyHeaders(hc, data, seals)
 	defer close(abort)
 
@@ -260,27 +265,28 @@ func (hc *HeaderChain) ValidateHeaderChain(chain []*types.Header, checkFreq int)
 // should be done or not. The reason behind the optional check is because some
 // of the header retrieval mechanisms already need to verfy nonces, as well as
 // because nonces can be verified sparsely, not needing to check each.
-func (hc *HeaderChain) InsertHeaderChain(chain []*types.Header, writeHeader WhCallback, start time.Time) (int, error) {
+func (hc *HeaderChain) InsertHeaderChain(dataBatch types.HeaderInsertDataBatch, writeData WhCallback, start time.Time) (int, error) {
 	// Collect some import statistics to report on
 	stats := struct{ processed, ignored int }{}
 	// All headers passed verification, import them into the database
-	for i, header := range chain {
+	for i, data := range dataBatch {
 		// Short circuit insertion if shutting down
 		if hc.procInterrupt() {
 			log.Debug("Premature abort during headers import")
 			return i, errors.New("aborted")
 		}
 		// If the header's already known, skip it, otherwise store
-		if hc.HasHeader(header.Hash(), header.Number.Uint64()) {
+		if hc.HasHeader(data.Header.Hash(), data.Header.Number.Uint64()) {
 			stats.ignored++
 			continue
 		}
-		if err := writeHeader(header); err != nil {
+		if err := writeData(data); err != nil {
 			return i, err
 		}
 		stats.processed++
 	}
 	// Report some public statistics so the user has a clue what's going on
+	chain, _ := dataBatch.Split()
 	last := chain[len(chain)-1]
 
 	context := []interface{}{

--- a/core/rawdb/accessors_branch_test.go
+++ b/core/rawdb/accessors_branch_test.go
@@ -23,7 +23,7 @@ func TestFindCommonAncestor(t *testing.T) {
 	//					^|
 	//				header03
 
-	dposCtx, err := types.NewDposContext(types.NewDposDb(db))
+	dposCtx, err := types.NewDposContext(types.NewFullDposDatabase(db))
 	if err != nil {
 		t.Fatalf("failed to new dpos context: %v", err)
 	}

--- a/core/rawdb/accessors_branch_test.go
+++ b/core/rawdb/accessors_branch_test.go
@@ -23,7 +23,7 @@ func TestFindCommonAncestor(t *testing.T) {
 	//					^|
 	//				header03
 
-	dposCtx, err := types.NewDposContext(db)
+	dposCtx, err := types.NewDposContext(types.NewDposDb(db))
 	if err != nil {
 		t.Fatalf("failed to new dpos context: %v", err)
 	}

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -27,7 +27,7 @@ import (
 // Tests block header storage and retrieval operations.
 func TestHeaderStorage(t *testing.T) {
 	db := ethdb.NewMemDatabase()
-	dposCtx, err := types.NewDposContext(db)
+	dposCtx, err := types.NewDposContext(types.NewDposDb(db))
 	if err != nil {
 		t.Fatalf("failed to new dpos context: %v", err)
 	}
@@ -64,7 +64,7 @@ func TestHeaderStorage(t *testing.T) {
 // Tests block body storage and retrieval operations.
 func TestBodyStorage(t *testing.T) {
 	db := ethdb.NewMemDatabase()
-	dposCtx, err := types.NewDposContext(db)
+	dposCtx, err := types.NewDposContext(types.NewDposDb(db))
 	if err != nil {
 		t.Fatalf("failed to new dpos context: %v", err)
 	}

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -27,7 +27,7 @@ import (
 // Tests block header storage and retrieval operations.
 func TestHeaderStorage(t *testing.T) {
 	db := ethdb.NewMemDatabase()
-	dposCtx, err := types.NewDposContext(types.NewDposDb(db))
+	dposCtx, err := types.NewDposContext(types.NewFullDposDatabase(db))
 	if err != nil {
 		t.Fatalf("failed to new dpos context: %v", err)
 	}
@@ -64,7 +64,7 @@ func TestHeaderStorage(t *testing.T) {
 // Tests block body storage and retrieval operations.
 func TestBodyStorage(t *testing.T) {
 	db := ethdb.NewMemDatabase()
-	dposCtx, err := types.NewDposContext(types.NewDposDb(db))
+	dposCtx, err := types.NewDposContext(types.NewFullDposDatabase(db))
 	if err != nil {
 		t.Fatalf("failed to new dpos context: %v", err)
 	}

--- a/core/types/dpos_context.go
+++ b/core/types/dpos_context.go
@@ -31,32 +31,27 @@ type DposContext struct {
 }
 
 var (
-	epochPrefix     = []byte("epoch-")
-	delegatePrefix  = []byte("delegate-")
-	votePrefix      = []byte("vote-")
-	candidatePrefix = []byte("candidate-")
-	minedCntPrefix  = []byte("minedCnt-")
-	keyValidator    = []byte("validator")
+	keyValidator = []byte("validator")
 )
 
 func NewEpochTrie(root common.Hash, db *trie.Database) (*trie.Trie, error) {
-	return trie.NewTrieWithPrefix(root, epochPrefix, db)
+	return trie.New(root, db)
 }
 
 func NewDelegateTrie(root common.Hash, db *trie.Database) (*trie.Trie, error) {
-	return trie.NewTrieWithPrefix(root, delegatePrefix, db)
+	return trie.New(root, db)
 }
 
 func NewVoteTrie(root common.Hash, db *trie.Database) (*trie.Trie, error) {
-	return trie.NewTrieWithPrefix(root, votePrefix, db)
+	return trie.New(root, db)
 }
 
 func NewCandidateTrie(root common.Hash, db *trie.Database) (*trie.Trie, error) {
-	return trie.NewTrieWithPrefix(root, candidatePrefix, db)
+	return trie.New(root, db)
 }
 
 func NewMinedCntTrie(root common.Hash, db *trie.Database) (*trie.Trie, error) {
-	return trie.NewTrieWithPrefix(root, minedCntPrefix, db)
+	return trie.New(root, db)
 }
 
 // NewDposContext creates DposContext with the given database

--- a/core/types/dpos_context.go
+++ b/core/types/dpos_context.go
@@ -550,10 +550,18 @@ func (dc *DposContext) SetMinedCnt(minedCnt DposTrie)   { dc.minedCntTrie = mine
 
 // GetValidators retrieves validator list in current epoch
 func (dc *DposContext) GetValidators() ([]common.Address, error) {
+	return GetValidatorsFromDposTrie(dc.epochTrie)
+}
+
+// GetValidatorsFromDposTrie get the list of validators from the trie
+func GetValidatorsFromDposTrie(t DposTrie) ([]common.Address, error) {
 	var validators []common.Address
-	validatorsRLP, err := dc.epochTrie.TryGet(keyValidator)
+	validatorsRLP, err := t.TryGet(keyValidator)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get validator: %v", err)
+	}
+	if len(validatorsRLP) == 0 {
+		return nil, fmt.Errorf("empty value for validators, make sure opening the epoch trie")
 	}
 	if err := rlp.DecodeBytes(validatorsRLP, &validators); err != nil {
 		return nil, fmt.Errorf("failed to decode validators: %s", err)

--- a/core/types/dpos_context.go
+++ b/core/types/dpos_context.go
@@ -38,8 +38,8 @@ var (
 // Implemented by both FullDposDatabase and light.DposDatabase
 type DposDatabase interface {
 	OpenEpochTrie(root common.Hash) (*trie.Trie, error)
-	OpenLastEpochTrie(root common.Hash) (*trie.Trie, error)
 	OpenDelegateTrie(root common.Hash) (*trie.Trie, error)
+	OpenLastDelegateTrie(root common.Hash) (*trie.Trie, error)
 	OpenVoteTrie(root common.Hash) (*trie.Trie, error)
 	OpenCandidateTrie(root common.Hash) (*trie.Trie, error)
 	OpenMinedCntTrie(root common.Hash) (*trie.Trie, error)
@@ -61,13 +61,13 @@ func (db *FullDposDatabase) OpenEpochTrie(root common.Hash) (*trie.Trie, error) 
 	return db.openTrie(root)
 }
 
-// OpenLastEpochTrie opens the epochTrie in the last epoch
-func (db *FullDposDatabase) OpenLastEpochTrie(root common.Hash) (*trie.Trie, error) {
+// OpenDelegateTrie opens the delegateTrie
+func (db *FullDposDatabase) OpenDelegateTrie(root common.Hash) (*trie.Trie, error) {
 	return db.openTrie(root)
 }
 
-// OpenDelegateTrie opens the delegateTrie
-func (db *FullDposDatabase) OpenDelegateTrie(root common.Hash) (*trie.Trie, error) {
+// OpenLastEpochTrie opens the epochTrie in the last epoch
+func (db *FullDposDatabase) OpenLastDelegateTrie(root common.Hash) (*trie.Trie, error) {
 	return db.openTrie(root)
 }
 

--- a/core/types/dpos_context.go
+++ b/core/types/dpos_context.go
@@ -35,9 +35,14 @@ var (
 )
 
 // DposDatabase is the underlying database under the dposCtx.
-// Implemented by both FullDposDatabase and light.OdrDposDatabase
+// Implemented by both FullDposDatabase and light.DposDatabase
 type DposDatabase interface {
-	OpenTrie(root common.Hash) (*trie.Trie, error)
+	OpenEpochTrie(root common.Hash) (*trie.Trie, error)
+	OpenLastEpochTrie(root common.Hash) (*trie.Trie, error)
+	OpenDelegateTrie(root common.Hash) (*trie.Trie, error)
+	OpenVoteTrie(root common.Hash) (*trie.Trie, error)
+	OpenCandidateTrie(root common.Hash) (*trie.Trie, error)
+	OpenMinedCntTrie(root common.Hash) (*trie.Trie, error)
 }
 
 // FullDposDatabase is the database for full node's dpos contents
@@ -45,40 +50,69 @@ type FullDposDatabase struct {
 	db *trie.Database
 }
 
-// NewDposDb creates a new FullDposDatabase based on a diskdb
-func NewDposDb(diskdb ethdb.Database) *FullDposDatabase {
+// NewFullDposDatabase creates a new FullDposDatabase based on a diskdb
+func NewFullDposDatabase(diskdb ethdb.Database) *FullDposDatabase {
 	tdb := trie.NewDatabase(diskdb)
 	return &FullDposDatabase{tdb}
 }
 
-// OpenTrie opens a trie with the given root
-func (db *FullDposDatabase) OpenTrie(root common.Hash) (*trie.Trie, error) {
+// OpenEpochTrie opens the epochTrie
+func (db *FullDposDatabase) OpenEpochTrie(root common.Hash) (*trie.Trie, error) {
+	return db.openTrie(root)
+}
+
+// OpenLastEpochTrie opens the epochTrie in the last epoch
+func (db *FullDposDatabase) OpenLastEpochTrie(root common.Hash) (*trie.Trie, error) {
+	return db.openTrie(root)
+}
+
+// OpenDelegateTrie opens the delegateTrie
+func (db *FullDposDatabase) OpenDelegateTrie(root common.Hash) (*trie.Trie, error) {
+	return db.openTrie(root)
+}
+
+// OpenVoteTrie opens the voteTrie
+func (db *FullDposDatabase) OpenVoteTrie(root common.Hash) (*trie.Trie, error) {
+	return db.openTrie(root)
+}
+
+// OpenCandidateTrie opens the CandidateTrie
+func (db *FullDposDatabase) OpenCandidateTrie(root common.Hash) (*trie.Trie, error) {
+	return db.openTrie(root)
+}
+
+// OpenMinedCntTrie opens the MinedCntTrie
+func (db *FullDposDatabase) OpenMinedCntTrie(root common.Hash) (*trie.Trie, error) {
+	return db.openTrie(root)
+}
+
+func (db *FullDposDatabase) openTrie(root common.Hash) (*trie.Trie, error) {
 	return trie.New(root, db.db)
 }
 
 // NewDposContext creates DposContext with the given database
 func NewDposContext(db DposDatabase) (*DposContext, error) {
-	epochTrie, err := db.OpenTrie(common.Hash{})
+	epochTrie, err := db.OpenEpochTrie(common.Hash{})
 	if err != nil {
 		return nil, err
 	}
 
-	delegateTrie, err := db.OpenTrie(common.Hash{})
+	delegateTrie, err := db.OpenDelegateTrie(common.Hash{})
 	if err != nil {
 		return nil, err
 	}
 
-	voteTrie, err := db.OpenTrie(common.Hash{})
+	voteTrie, err := db.OpenVoteTrie(common.Hash{})
 	if err != nil {
 		return nil, err
 	}
 
-	candidateTrie, err := db.OpenTrie(common.Hash{})
+	candidateTrie, err := db.OpenCandidateTrie(common.Hash{})
 	if err != nil {
 		return nil, err
 	}
 
-	minedCntTrie, err := db.OpenTrie(common.Hash{})
+	minedCntTrie, err := db.OpenMinedCntTrie(common.Hash{})
 	if err != nil {
 		return nil, err
 	}
@@ -95,27 +129,27 @@ func NewDposContext(db DposDatabase) (*DposContext, error) {
 
 // NewDposContextFromProto creates DposContext with database and trie root
 func NewDposContextFromProto(db DposDatabase, ctxProto *DposContextRoot) (*DposContext, error) {
-	epochTrie, err := db.OpenTrie(ctxProto.EpochRoot)
+	epochTrie, err := db.OpenEpochTrie(ctxProto.EpochRoot)
 	if err != nil {
 		return nil, err
 	}
 
-	delegateTrie, err := db.OpenTrie(ctxProto.DelegateRoot)
+	delegateTrie, err := db.OpenDelegateTrie(ctxProto.DelegateRoot)
 	if err != nil {
 		return nil, err
 	}
 
-	voteTrie, err := db.OpenTrie(ctxProto.VoteRoot)
+	voteTrie, err := db.OpenVoteTrie(ctxProto.VoteRoot)
 	if err != nil {
 		return nil, err
 	}
 
-	candidateTrie, err := db.OpenTrie(ctxProto.CandidateRoot)
+	candidateTrie, err := db.OpenCandidateTrie(ctxProto.CandidateRoot)
 	if err != nil {
 		return nil, err
 	}
 
-	minedCntTrie, err := db.OpenTrie(ctxProto.MinedCntRoot)
+	minedCntTrie, err := db.OpenMinedCntTrie(ctxProto.MinedCntRoot)
 	if err != nil {
 		return nil, err
 	}

--- a/core/types/dpos_context_test.go
+++ b/core/types/dpos_context_test.go
@@ -128,13 +128,13 @@ func TestDposContextVoteAndCancelVote(t *testing.T) {
 	assert.Nil(t, err)
 	delegateIter := trie.NewIterator(dposContext.delegateTrie.PrefixIterator(candidate.Bytes()))
 	if assert.True(t, delegateIter.Next()) {
-		assert.Equal(t, append(delegatePrefix, append(candidate.Bytes(), delegator.Bytes()...)...), delegateIter.Key)
+		assert.Equal(t, append(candidate.Bytes(), delegator.Bytes()...), delegateIter.Key)
 		assert.Equal(t, delegator, common.BytesToAddress(delegateIter.Value))
 	}
 
 	voteIter := trie.NewIterator(dposContext.voteTrie.NodeIterator(nil))
 	if assert.True(t, voteIter.Next()) {
-		assert.Equal(t, append(votePrefix, delegator.Bytes()...), voteIter.Key)
+		assert.Equal(t, delegator.Bytes(), voteIter.Key)
 		assert.Equal(t, candidate, common.BytesToAddress(voteIter.Value))
 	}
 
@@ -145,13 +145,13 @@ func TestDposContextVoteAndCancelVote(t *testing.T) {
 	assert.False(t, delegateIter.Next())
 	delegateIter = trie.NewIterator(dposContext.delegateTrie.PrefixIterator(newCandidate.Bytes()))
 	if assert.True(t, delegateIter.Next()) {
-		assert.Equal(t, append(delegatePrefix, append(newCandidate.Bytes(), delegator.Bytes()...)...), delegateIter.Key)
+		assert.Equal(t, append(newCandidate.Bytes(), delegator.Bytes()...), delegateIter.Key)
 		assert.Equal(t, delegator, common.BytesToAddress(delegateIter.Value))
 	}
 
 	voteIter = trie.NewIterator(dposContext.voteTrie.NodeIterator(nil))
 	if assert.True(t, voteIter.Next()) {
-		assert.Equal(t, append(votePrefix, delegator.Bytes()...), voteIter.Key)
+		assert.Equal(t, delegator.Bytes(), voteIter.Key)
 		assert.Equal(t, newCandidate, common.BytesToAddress(voteIter.Value))
 	}
 

--- a/core/types/dpos_context_test.go
+++ b/core/types/dpos_context_test.go
@@ -26,7 +26,7 @@ var (
 
 func TestDposContextSnapshot(t *testing.T) {
 	db := ethdb.NewMemDatabase()
-	dposContext, err := NewDposContext(db)
+	dposContext, err := NewDposContext(NewDposDb(db))
 	assert.Nil(t, err)
 
 	snapshot := dposContext.Snapshot()
@@ -46,7 +46,7 @@ func TestDposContextSnapshot(t *testing.T) {
 func TestDposContextBecomeCandidate(t *testing.T) {
 	candidates := addresses
 	db := ethdb.NewMemDatabase()
-	dposContext, err := NewDposContext(db)
+	dposContext, err := NewDposContext(NewDposDb(db))
 	assert.Nil(t, err)
 	for _, candidate := range candidates {
 		assert.Nil(t, dposContext.BecomeCandidate(candidate))
@@ -67,7 +67,7 @@ func TestDposContextBecomeCandidate(t *testing.T) {
 func TestDposContextKickoutCandidate(t *testing.T) {
 	candidates := addresses
 	db := ethdb.NewMemDatabase()
-	dposContext, err := NewDposContext(db)
+	dposContext, err := NewDposContext(NewDposDb(db))
 	assert.Nil(t, err)
 	for _, candidate := range candidates {
 		assert.Nil(t, dposContext.BecomeCandidate(candidate))
@@ -108,7 +108,7 @@ func TestDposContextVoteAndCancelVote(t *testing.T) {
 	newCandidate := addresses[1]
 	delegator := addresses[2]
 	db := ethdb.NewMemDatabase()
-	dposContext, err := NewDposContext(db)
+	dposContext, err := NewDposContext(NewDposDb(db))
 	assert.Nil(t, err)
 	assert.Nil(t, dposContext.BecomeCandidate(candidate))
 	assert.Nil(t, dposContext.BecomeCandidate(newCandidate))
@@ -169,7 +169,7 @@ func TestDposContextVoteAndCancelVote(t *testing.T) {
 func TestDposContextValidators(t *testing.T) {
 	validators := addresses
 	db := ethdb.NewMemDatabase()
-	dposContext, err := NewDposContext(db)
+	dposContext, err := NewDposContext(NewDposDb(db))
 
 	assert.Nil(t, err)
 	assert.Nil(t, dposContext.SetValidators(validators))
@@ -190,7 +190,7 @@ func TestDposContextValidators(t *testing.T) {
 
 func TestDposContext_GetVotedCandidatesByAddress(t *testing.T) {
 	db := ethdb.NewMemDatabase()
-	dposContext, err := NewDposContext(db)
+	dposContext, err := NewDposContext(NewDposDb(db))
 	assert.Nil(t, err)
 
 	bytes, err := rlp.EncodeToBytes(addresses)

--- a/core/types/dpos_context_test.go
+++ b/core/types/dpos_context_test.go
@@ -26,7 +26,7 @@ var (
 
 func TestDposContextSnapshot(t *testing.T) {
 	db := ethdb.NewMemDatabase()
-	dposContext, err := NewDposContext(NewDposDb(db))
+	dposContext, err := NewDposContext(NewFullDposDatabase(db))
 	assert.Nil(t, err)
 
 	snapshot := dposContext.Snapshot()
@@ -46,7 +46,7 @@ func TestDposContextSnapshot(t *testing.T) {
 func TestDposContextBecomeCandidate(t *testing.T) {
 	candidates := addresses
 	db := ethdb.NewMemDatabase()
-	dposContext, err := NewDposContext(NewDposDb(db))
+	dposContext, err := NewDposContext(NewFullDposDatabase(db))
 	assert.Nil(t, err)
 	for _, candidate := range candidates {
 		assert.Nil(t, dposContext.BecomeCandidate(candidate))
@@ -67,7 +67,7 @@ func TestDposContextBecomeCandidate(t *testing.T) {
 func TestDposContextKickoutCandidate(t *testing.T) {
 	candidates := addresses
 	db := ethdb.NewMemDatabase()
-	dposContext, err := NewDposContext(NewDposDb(db))
+	dposContext, err := NewDposContext(NewFullDposDatabase(db))
 	assert.Nil(t, err)
 	for _, candidate := range candidates {
 		assert.Nil(t, dposContext.BecomeCandidate(candidate))
@@ -108,7 +108,7 @@ func TestDposContextVoteAndCancelVote(t *testing.T) {
 	newCandidate := addresses[1]
 	delegator := addresses[2]
 	db := ethdb.NewMemDatabase()
-	dposContext, err := NewDposContext(NewDposDb(db))
+	dposContext, err := NewDposContext(NewFullDposDatabase(db))
 	assert.Nil(t, err)
 	assert.Nil(t, dposContext.BecomeCandidate(candidate))
 	assert.Nil(t, dposContext.BecomeCandidate(newCandidate))
@@ -169,7 +169,7 @@ func TestDposContextVoteAndCancelVote(t *testing.T) {
 func TestDposContextValidators(t *testing.T) {
 	validators := addresses
 	db := ethdb.NewMemDatabase()
-	dposContext, err := NewDposContext(NewDposDb(db))
+	dposContext, err := NewDposContext(NewFullDposDatabase(db))
 
 	assert.Nil(t, err)
 	assert.Nil(t, dposContext.SetValidators(validators))
@@ -190,7 +190,7 @@ func TestDposContextValidators(t *testing.T) {
 
 func TestDposContext_GetVotedCandidatesByAddress(t *testing.T) {
 	db := ethdb.NewMemDatabase()
-	dposContext, err := NewDposContext(NewDposDb(db))
+	dposContext, err := NewDposContext(NewFullDposDatabase(db))
 	assert.Nil(t, err)
 
 	bytes, err := rlp.EncodeToBytes(addresses)

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -169,7 +169,7 @@ type LightChain interface {
 	GetTd(common.Hash, uint64) *big.Int
 
 	// InsertHeaderChain inserts a batch of headers into the local chain.
-	InsertHeaderChain([]*types.Header, int) (int, error)
+	InsertHeaderChain(types.HeaderInsertDataBatch, int) (int, error)
 
 	// Rollback removes a few recently added elements from the local chain.
 	Rollback([]common.Hash)

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -200,9 +200,11 @@ func (dl *downloadTester) GetTd(hash common.Hash, number uint64) *big.Int {
 }
 
 // InsertHeaderChain injects a new batch of headers into the simulated chain.
-func (dl *downloadTester) InsertHeaderChain(headers []*types.Header, checkFreq int) (i int, err error) {
+func (dl *downloadTester) InsertHeaderChain(data types.HeaderInsertDataBatch, checkFreq int) (i int, err error) {
 	dl.lock.Lock()
 	defer dl.lock.Unlock()
+
+	headers, _ := data.Split()
 
 	// Do a quick check, as the blockchain.InsertHeaderChain doesn't insert anything in case of errors
 	if _, ok := dl.ownHeaders[headers[0].ParentHash]; !ok {

--- a/eth/dpos_api.go
+++ b/eth/dpos_api.go
@@ -12,7 +12,6 @@ import (
 	"github.com/DxChainNetwork/godx/consensus/dpos"
 	"github.com/DxChainNetwork/godx/core/types"
 	"github.com/DxChainNetwork/godx/rpc"
-	"github.com/DxChainNetwork/godx/trie"
 )
 
 // PublicDposAPI object is used to implement all
@@ -123,8 +122,8 @@ func (d *PublicDposAPI) Candidate(candidateAddress common.Address, blockNr *rpc.
 	}
 
 	// get detailed information
-	trieDb := trie.NewDatabase(d.e.ChainDb())
-	candidateDeposit, candidateVotes, rewardRatio, err := dpos.GetCandidateInfo(statedb, candidateAddress, header, trieDb)
+	diskdb := d.e.ChainDb()
+	candidateDeposit, candidateVotes, rewardRatio, err := dpos.GetCandidateInfo(statedb, candidateAddress, header, diskdb)
 	if err != nil {
 		return CandidateInfo{}, err
 	}

--- a/les/handler.go
+++ b/les/handler.go
@@ -78,7 +78,7 @@ type BlockChain interface {
 	State() (*state.StateDB, error)
 	DposCtx() (*types.DposContext, error)
 	DposCtxAt(*types.DposContextRoot) (*types.DposContext, error)
-	InsertHeaderChain(chain []*types.Header, checkFreq int) (int, error)
+	InsertHeaderChain(chain types.HeaderInsertDataBatch, checkFreq int) (int, error)
 	Rollback(chain []common.Hash)
 	GetHeaderByNumber(number uint64) *types.Header
 	GetAncestor(hash common.Hash, number, ancestor uint64, maxNonCanonical *uint64) (common.Hash, uint64)

--- a/les/handler.go
+++ b/les/handler.go
@@ -1271,7 +1271,7 @@ func (ctx *dposProofMsgCtx) openDposCtx(blockHash common.Hash) {
 	ctx.lastBlockHash = blockHash
 }
 
-func selectDposTrie(dposCtx *types.DposContext, spec light.DposTrieSpecifier) *trie.Trie {
+func selectDposTrie(dposCtx *types.DposContext, spec light.DposTrieSpecifier) types.DposTrie {
 	switch spec {
 	case light.EpochTrieSpec:
 		return dposCtx.EpochTrie()

--- a/light/dpos_trie.go
+++ b/light/dpos_trie.go
@@ -3,3 +3,91 @@
 // License 2.0 that can be found in the LICENSE file
 
 package light
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/DxChainNetwork/godx/trie"
+
+	"github.com/DxChainNetwork/godx/common"
+	"github.com/DxChainNetwork/godx/core/types"
+)
+
+type dposDatabaseID struct {
+	blockHash   common.Hash
+	blockNumber uint64
+	roots       types.DposContextRoot
+}
+
+type dposOdrDatabase struct {
+	ctx     context.Context
+	id      *dposDatabaseID
+	backend OdrBackend
+}
+
+func NewOdrDposDatabase(ctx context.Context, header *types.Header, odr OdrBackend) *dposOdrDatabase {
+	return &dposOdrDatabase{
+		ctx:     ctx,
+		id:      DposDatabaseIDFromHeader(header),
+		backend: odr,
+	}
+}
+
+// DposTrieIDFromHeader returns a DposTrieID from a block header
+func DposDatabaseIDFromHeader(header *types.Header, trieSpec DposTrieSpecifier) *dposDatabaseID {
+	return &dposDatabaseID{
+		blockHash:   header.Hash(),
+		blockNumber: header.Number.Uint64(),
+		roots:       *header.DposContext.Copy(),
+	}
+}
+
+// dposDatabaseIDToTrieID convert a dposDatabaseID to DposTrieID
+func dposDatabaseIDToTrieID(id *dposDatabaseID, spec DposTrieSpecifier) *DposTrieID {
+	return &DposTrieID{
+		BlockHash: id.blockHash,
+		BlockNumber: id.blockNumber,
+		Roots: id.roots,
+		TrieSpec: spec,
+	}
+}
+
+// OpenEpochTrie opens the epoch trie
+func (db *dposOdrDatabase) OpenEpochTrie(root common.Hash) (*odrDposTrie, error) {
+	id := dposDatabaseIDToTrieID(db.id, EpochTrieSpec)
+	return &odrDposTrie {
+		db: db,
+		id: id,
+	}, nil
+}
+
+// OpenLastEpochTrie open the epoch trie in the last epoch
+func (db *dposOdrDatabase) OpenLastEpochTrie(root common.Hash) (*odrDposTrie, error) {
+	return nil, errors.New("light node does not support accumulate reward")
+}
+
+// OpenDelegateTrie open the delegate trie
+func (db *dposOdrDatabase) OpenDelegateTrie(root common.Hash) (*odrDposTrie, error) {
+	id := dposDatabaseIDToTrieID(db.id, DelegateTrieSpec)
+	return &odrDposTrie{
+		db: db,
+		id: id,
+	}, nil
+}
+
+func (db *dposOdrDatabase) OpenVoteTrie(root common.Hash) (*odrDposTrie, error) {
+	//id :=
+}
+
+func (db *dposOdrDatabase) openTrie(root common.Hash, spec DposTrieSpecifier) (*odrDposTrie, error) {
+
+}
+
+type odrDposTrie struct {
+	db *dposOdrDatabase
+	id *DposTrieID
+	trie *trie.Trie
+}
+
+func (t *odrTrie)

--- a/light/dpos_trie.go
+++ b/light/dpos_trie.go
@@ -55,38 +55,53 @@ func dposDatabaseIDToTrieID(id *dposDatabaseID, spec DposTrieSpecifier) *DposTri
 }
 
 // OpenEpochTrie opens the epoch trie
-func (db *dposOdrDatabase) OpenEpochTrie(root common.Hash) (*odrDposTrie, error) {
+func (db *dposOdrDatabase) OpenEpochTrie(root common.Hash) (types.DposTrie, error) {
 	return db.openTrie(EpochTrieSpec)
 }
 
 // OpenDelegateTrie open the delegate trie
-func (db *dposOdrDatabase) OpenDelegateTrie(root common.Hash) (*odrDposTrie, error) {
+func (db *dposOdrDatabase) OpenDelegateTrie(root common.Hash) (types.DposTrie, error) {
 	return db.openTrie(DelegateTrieSpec)
 }
 
 // OpenLastEpochTrie open the epoch trie in the last epoch
-func (db *dposOdrDatabase) OpenLastDelegateTrie(root common.Hash) (*odrDposTrie, error) {
+func (db *dposOdrDatabase) OpenLastDelegateTrie(root common.Hash) (types.DposTrie, error) {
 	return nil, errors.New("light node does not support accumulate reward")
 }
 
 // OpenVoteTrie open the vote trie
-func (db *dposOdrDatabase) OpenVoteTrie(root common.Hash) (*odrDposTrie, error) {
+func (db *dposOdrDatabase) OpenVoteTrie(root common.Hash) (types.DposTrie, error) {
 	return db.openTrie(VoteTrieSpec)
 }
 
 // OpenCandidateTrie opens the candidate trie
-func (db *dposOdrDatabase) OpenCandidateTrie(root common.Hash) (*odrDposTrie, error) {
+func (db *dposOdrDatabase) OpenCandidateTrie(root common.Hash) (types.DposTrie, error) {
 	return db.openTrie(CandidateTrieSpec)
 }
 
 // OpenMinedCntTrie opens the mined count trie
-func (db *dposOdrDatabase) OpenMinedCntTrie(root common.Hash) (*odrDposTrie, error) {
+func (db *dposOdrDatabase) OpenMinedCntTrie(root common.Hash) (types.DposTrie, error) {
 	return db.openTrie(MinedCntTrieSpec)
 }
 
-func (db *dposOdrDatabase) openTrie(spec DposTrieSpecifier) (*odrDposTrie, error) {
+func (db *dposOdrDatabase) openTrie(spec DposTrieSpecifier) (types.DposTrie, error) {
 	id := dposDatabaseIDToTrieID(db.id, spec)
 	return &odrDposTrie{db: db, id: id}, nil
+}
+
+// CopyTrie copies a dpos trie
+func (db *dposOdrDatabase) CopyTrie(t types.DposTrie) types.DposTrie {
+	switch t := t.(type) {
+	case *odrDposTrie:
+		cpy := &odrDposTrie{db: t.db, id: t.id}
+		if t.trie != nil {
+			cpyTrie := *t.trie
+			cpy.trie = &cpyTrie
+		}
+		return cpy
+	default:
+		panic(fmt.Errorf("unknown trie type %T", t))
+	}
 }
 
 // odrDposTrie is the trie data structure for light node which sits on top of lesOdrBackend that

--- a/light/dpos_trie.go
+++ b/light/dpos_trie.go
@@ -8,10 +8,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/DxChainNetwork/godx/trie"
 
 	"github.com/DxChainNetwork/godx/common"
 	"github.com/DxChainNetwork/godx/core/types"
+	"github.com/DxChainNetwork/godx/ethdb"
+	"github.com/DxChainNetwork/godx/trie"
 )
 
 type dposDatabaseID struct {
@@ -35,7 +36,7 @@ func NewOdrDposDatabase(ctx context.Context, header *types.Header, odr OdrBacken
 }
 
 // DposTrieIDFromHeader returns a DposTrieID from a block header
-func DposDatabaseIDFromHeader(header *types.Header, trieSpec DposTrieSpecifier) *dposDatabaseID {
+func DposDatabaseIDFromHeader(header *types.Header) *dposDatabaseID {
 	return &dposDatabaseID{
 		blockHash:   header.Hash(),
 		blockNumber: header.Number.Uint64(),
@@ -46,20 +47,16 @@ func DposDatabaseIDFromHeader(header *types.Header, trieSpec DposTrieSpecifier) 
 // dposDatabaseIDToTrieID convert a dposDatabaseID to DposTrieID
 func dposDatabaseIDToTrieID(id *dposDatabaseID, spec DposTrieSpecifier) *DposTrieID {
 	return &DposTrieID{
-		BlockHash: id.blockHash,
+		BlockHash:   id.blockHash,
 		BlockNumber: id.blockNumber,
-		Roots: id.roots,
-		TrieSpec: spec,
+		Roots:       id.roots,
+		TrieSpec:    spec,
 	}
 }
 
 // OpenEpochTrie opens the epoch trie
 func (db *dposOdrDatabase) OpenEpochTrie(root common.Hash) (*odrDposTrie, error) {
-	id := dposDatabaseIDToTrieID(db.id, EpochTrieSpec)
-	return &odrDposTrie {
-		db: db,
-		id: id,
-	}, nil
+	return db.openTrie(EpochTrieSpec)
 }
 
 // OpenLastEpochTrie open the epoch trie in the last epoch
@@ -69,25 +66,193 @@ func (db *dposOdrDatabase) OpenLastEpochTrie(root common.Hash) (*odrDposTrie, er
 
 // OpenDelegateTrie open the delegate trie
 func (db *dposOdrDatabase) OpenDelegateTrie(root common.Hash) (*odrDposTrie, error) {
-	id := dposDatabaseIDToTrieID(db.id, DelegateTrieSpec)
-	return &odrDposTrie{
-		db: db,
-		id: id,
-	}, nil
+	return db.openTrie(DelegateTrieSpec)
 }
 
+// OpenVoteTrie open the vote trie
 func (db *dposOdrDatabase) OpenVoteTrie(root common.Hash) (*odrDposTrie, error) {
-	//id :=
+	return db.openTrie(VoteTrieSpec)
 }
 
-func (db *dposOdrDatabase) openTrie(root common.Hash, spec DposTrieSpecifier) (*odrDposTrie, error) {
-
+// OpenCandidateTrie opens the candidate trie
+func (db *dposOdrDatabase) OpenCandidateTrie(root common.Hash) (*odrDposTrie, error) {
+	return db.openTrie(CandidateTrieSpec)
 }
 
+// OpenMinedCntTrie opens the mined count trie
+func (db *dposOdrDatabase) OpenMinedCntTrie(root common.Hash) (*odrDposTrie, error) {
+	return db.openTrie(MinedCntTrieSpec)
+}
+
+func (db *dposOdrDatabase) openTrie(spec DposTrieSpecifier) (*odrDposTrie, error) {
+	id := dposDatabaseIDToTrieID(db.id, spec)
+	return &odrDposTrie{db: db, id: id}, nil
+}
+
+// odrDposTrie is the trie data structure for light node which sits on top of lesOdrBackend that
+// helps retrieve trie data from the les server.
 type odrDposTrie struct {
-	db *dposOdrDatabase
-	id *DposTrieID
+	db   *dposOdrDatabase
+	id   *DposTrieID
 	trie *trie.Trie
 }
 
-func (t *odrTrie)
+// TryGet try to retrieve the value for the key
+func (t *odrDposTrie) TryGet(key []byte) ([]byte, error) {
+	var res []byte
+	err := t.do(key, func() (err error) {
+		res, err = t.trie.TryGet(key)
+		return err
+	})
+	return res, err
+}
+
+// TryUpdate try to update the key value pair in the trie
+func (t *odrDposTrie) TryUpdate(key, value []byte) error {
+	return t.do(key, func() error {
+		return t.trie.TryUpdate(key, value)
+	})
+}
+
+// TryDelete try to delete the key in the trie
+func (t *odrDposTrie) TryDelete(key []byte) error {
+	return t.do(key, func() error {
+		return t.trie.TryDelete(key)
+	})
+}
+
+// Commit commit the trie to trie db
+func (t *odrDposTrie) Commit(onleaf trie.LeafCallback) (common.Hash, error) {
+	if t.trie == nil {
+		return t.id.TargetRoot(), nil
+	}
+	return t.trie.Commit(onleaf)
+}
+
+// Hash returns the hash of the trie
+func (t *odrDposTrie) Hash() common.Hash {
+	if t.trie == nil {
+		return t.id.TargetRoot()
+	}
+	return t.trie.Hash()
+}
+
+// NodeIterator return the node iterator of the odrDposTrie
+func (t *odrDposTrie) NodeIterator(startKey []byte) trie.NodeIterator {
+	return newDposNodeIterator(t, startKey)
+}
+
+// PrefixIterator return the prefix iterator of the given prefix for the odrDposTrie.
+// Note that
+func (t *odrDposTrie) PrefixIterator(prefix []byte) trie.NodeIterator {
+	return newDposPrefixIterator(t, prefix)
+}
+
+// Prove put the proof of the specified key to proofDb
+func (t *odrDposTrie) Prove(key []byte, fromLevel uint, proofDb ethdb.Putter) error {
+	return errors.New("not implemented")
+}
+
+// do tries and retries to execute a function until it returns with no error or
+// an error type other than MissingNodeError
+func (t *odrDposTrie) do(key []byte, fn func() error) error {
+	for {
+		var err error
+		if t.trie == nil {
+			t.trie, err = trie.New(t.id.TargetRoot(), trie.NewDatabase(t.db.backend.Database()))
+		}
+		if err == nil {
+			err = fn()
+		}
+		if _, ok := err.(*trie.MissingNodeError); !ok {
+			return err
+		}
+		r := &DposTrieRequest{ID: t.id, Key: key}
+		if err := t.db.backend.Retrieve(t.db.ctx, r); err != nil {
+			return err
+		}
+	}
+}
+
+type dposNodeIterator struct {
+	trie.NodeIterator
+	t   *odrDposTrie
+	err error
+}
+
+// newDposPrefixIterator creates a dposNodeIterator which iterates over the given prefix
+// for the give odrDposTrie
+func newDposPrefixIterator(t *odrDposTrie, prefix []byte) trie.NodeIterator {
+	it := &dposNodeIterator{t: t}
+	if t.trie == nil {
+		it.do(func() error {
+			t, err := trie.New(t.id.TargetRoot(), trie.NewDatabase(t.db.backend.Database()))
+			if err == nil {
+				it.t.trie = t
+			}
+			return err
+		})
+	}
+	it.do(func() error {
+		it.NodeIterator = it.t.trie.PrefixIterator(prefix)
+		return it.NodeIterator.Error()
+	})
+	return it
+}
+
+// newDposNodeIterator creates a dposNodeIterator which iterates from the given key
+func newDposNodeIterator(t *odrDposTrie, start []byte) trie.NodeIterator {
+	it := &dposNodeIterator{t: t}
+	if t.trie == nil {
+		it.do(func() error {
+			t, err := trie.New(t.id.TargetRoot(), trie.NewDatabase(t.db.backend.Database()))
+			if err == nil {
+				it.t.trie = t
+			}
+			return err
+		})
+	}
+	it.do(func() error {
+		it.NodeIterator = it.t.trie.NodeIterator(start)
+		return it.NodeIterator.Error()
+	})
+	return it
+}
+
+// Next iterate to the next entry.
+func (it *dposNodeIterator) Next(descend bool) bool {
+	var ok bool
+	it.do(func() error {
+		ok = it.NodeIterator.Next(descend)
+		return it.NodeIterator.Error()
+	})
+	return ok
+}
+
+func (it *dposNodeIterator) do(fn func() error) {
+	var lastHash common.Hash
+	for {
+		it.err = fn()
+		missing, ok := it.err.(*trie.MissingNodeError)
+		if !ok {
+			return
+		}
+		if missing.NodeHash == lastHash {
+			it.err = fmt.Errorf("retrieve loop for trie node %x", missing.NodeHash)
+			return
+		}
+		lastHash = missing.NodeHash
+		r := &DposTrieRequest{ID: it.t.id, Key: nibblesToKey(missing.Path)}
+		if it.err = it.t.db.backend.Retrieve(it.t.db.ctx, r); it.err != nil {
+			return
+		}
+	}
+}
+
+// Error return the error for the node iterator
+func (it *dposNodeIterator) Error() error {
+	if it.err != nil {
+		return it.err
+	}
+	return it.NodeIterator.Error()
+}

--- a/light/dpos_trie.go
+++ b/light/dpos_trie.go
@@ -15,6 +15,13 @@ import (
 	"github.com/DxChainNetwork/godx/trie"
 )
 
+// NewDposContext creates a new dposContext
+func NewDposContext(ctx context.Context, header *types.Header, odr OdrBackend) *types.DposContext {
+	db := NewOdrDposDatabase(ctx, header, odr)
+	dposCtx, _ := types.NewDposContextFromProto(db, header.DposContext)
+	return dposCtx
+}
+
 type dposDatabaseID struct {
 	blockHash   common.Hash
 	blockNumber uint64

--- a/light/dpos_trie.go
+++ b/light/dpos_trie.go
@@ -59,14 +59,14 @@ func (db *dposOdrDatabase) OpenEpochTrie(root common.Hash) (*odrDposTrie, error)
 	return db.openTrie(EpochTrieSpec)
 }
 
-// OpenLastEpochTrie open the epoch trie in the last epoch
-func (db *dposOdrDatabase) OpenLastEpochTrie(root common.Hash) (*odrDposTrie, error) {
-	return nil, errors.New("light node does not support accumulate reward")
-}
-
 // OpenDelegateTrie open the delegate trie
 func (db *dposOdrDatabase) OpenDelegateTrie(root common.Hash) (*odrDposTrie, error) {
 	return db.openTrie(DelegateTrieSpec)
+}
+
+// OpenLastEpochTrie open the epoch trie in the last epoch
+func (db *dposOdrDatabase) OpenLastDelegateTrie(root common.Hash) (*odrDposTrie, error) {
+	return nil, errors.New("light node does not support accumulate reward")
 }
 
 // OpenVoteTrie open the vote trie

--- a/light/odr.go
+++ b/light/odr.go
@@ -214,16 +214,6 @@ type DposTrieID struct {
 	TrieSpec    DposTrieSpecifier
 }
 
-// DposTrieIDFromHeader returns a DposTrieID from a block header
-func DposTrieIDFromHeader(header *types.Header, trieSpec DposTrieSpecifier) *DposTrieID {
-	return &DposTrieID{
-		BlockHash:   header.Hash(),
-		BlockNumber: header.Number.Uint64(),
-		Roots:       *header.DposContext.Copy(),
-		TrieSpec:    trieSpec,
-	}
-}
-
 // TargetRoot return the target root for a DposTrieID
 func (id *DposTrieID) TargetRoot() common.Hash {
 	switch id.TrieSpec {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -500,7 +500,7 @@ func (w *worker) makeCurrent(parent *types.Block, header *types.Header) error {
 
 	// construct dpos context from parent's dpos context root
 	chainDB := stateDB.Database().TrieDB().DiskDB().(ethdb.Database)
-	dposContext, err := types.NewDposContextFromProto(types.NewDposDb(chainDB), parent.Header().DposContext)
+	dposContext, err := types.NewDposContextFromProto(types.NewFullDposDatabase(chainDB), parent.Header().DposContext)
 	if err != nil {
 		log.Error("failed to create dpos context", "error", err)
 		return err

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -500,7 +500,7 @@ func (w *worker) makeCurrent(parent *types.Block, header *types.Header) error {
 
 	// construct dpos context from parent's dpos context root
 	chainDB := stateDB.Database().TrieDB().DiskDB().(ethdb.Database)
-	dposContext, err := types.NewDposContextFromProto(chainDB, parent.Header().DposContext)
+	dposContext, err := types.NewDposContextFromProto(types.NewDposDb(chainDB), parent.Header().DposContext)
 	if err != nil {
 		log.Error("failed to create dpos context", "error", err)
 		return err

--- a/params/config.go
+++ b/params/config.go
@@ -25,8 +25,8 @@ import (
 
 // Genesis hashes to enforce below configs on.
 var (
-	MainnetGenesisHash = common.HexToHash("22fb425009102548ecc0a720068b7c2deeb146072d65c396aa0a33a7bd01cbea")
-	TestnetGenesisHash = common.HexToHash("b35da689074a7313d5d19cc6d5fd4cca47d9f36d00f995096c7e750384cfef3e")
+	MainnetGenesisHash = common.HexToHash("0xf23ba5f615f1001641d1b2241771cc3de5baa52c98e3b09b6bbd3f3b96f09ec0")
+	TestnetGenesisHash = common.HexToHash("0x5751c2f5c2489e7535909c4ec36c18bdb3da7a78191a100c04650af85d08216a")
 	RinkebyGenesisHash = common.HexToHash("0x6341fd3daf94b748c72ced5a5b26028f2474f5f00d824504e4fa37a75767e177")
 )
 

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -21,9 +21,8 @@ type (
 	//
 	// Trie is not safe for concurrent use.
 	Trie struct {
-		db     *Database
-		root   node
-		prefix []byte
+		db   *Database
+		root node
 
 		// Cache generation values.
 		// cachegen increases by one each commit operation
@@ -84,33 +83,15 @@ func New(root common.Hash, db *Database) (*Trie, error) {
 	return trie, nil
 }
 
-// NewTrieWithPrefix creates a trie with an existing root node that has the specified prefix
-func NewTrieWithPrefix(root common.Hash, prefix []byte, db *Database) (*Trie, error) {
-	trie, err := New(root, db)
-	if err != nil {
-		return nil, err
-	}
-	trie.prefix = prefix
-	return trie, nil
-}
-
 // NodeIterator returns an iterator that returns nodes of the trie. Iteration
 // starts at the key after the given start key
 func (t *Trie) NodeIterator(start []byte) NodeIterator {
-	if t.prefix != nil {
-		start = append(t.prefix, start...)
-	}
-
 	return newNodeIterator(t, start)
 }
 
 // PrefixIterator returns an iterator that returns nodes of the trie with the specified prefix path,
 // it will start iteration at the key after the given prefix path.
 func (t *Trie) PrefixIterator(prefix []byte) NodeIterator {
-	if t.prefix != nil {
-		prefix = append(t.prefix, prefix...)
-	}
-
 	return newPrefixIterator(t, prefix)
 }
 
@@ -128,10 +109,6 @@ func (t *Trie) Get(key []byte) []byte {
 // The value bytes must not be modified by the caller.
 // If a node was not found in the database, a MissingNodeError is returned.
 func (t *Trie) TryGet(key []byte) ([]byte, error) {
-	if t.prefix != nil {
-		key = append(t.prefix, key...)
-	}
-
 	key = keybytesToHex(key)
 	value, newroot, didResolve, err := t.tryGet(t.root, key, 0)
 	if err == nil && didResolve {
@@ -206,10 +183,6 @@ func (t *Trie) Update(key, value []byte) {
 //
 // If a node was not found in the database, a MissingNodeError is returned.
 func (t *Trie) TryUpdate(key, value []byte) error {
-	if t.prefix != nil {
-		key = append(t.prefix, key...)
-	}
-
 	k := keybytesToHex(key)
 	if len(value) != 0 {
 		_, n, err := t.insert(t.root, nil, k, valueNode(value))
@@ -335,10 +308,6 @@ func (t *Trie) Delete(key []byte) {
 // TryDelete removes any existing value for key from the trie
 // If a node was not found in the database, a MissingNodeError is returned.
 func (t *Trie) TryDelete(key []byte) error {
-	if t.prefix != nil {
-		key = append(t.prefix, key...)
-	}
-
 	k := keybytesToHex(key)
 	_, n, err := t.delete(t.root, nil, k)
 	if err != nil {


### PR DESCRIPTION
### Description

1. Refactored dpos.verifySeal function.
2. Added verify seal to dpos.verifyHeader and dpos.VerifyHeaders
3. Changed signature InsertHeaderChain for all related interface and implementation. Replace []*types.Header to types.HeaderInsertDataBatch. Change related codes as necessary.
4. Updated blockchain.InsertChain code. verifyHeader called after the last block is inserted.