### PR TITLE
Light node/insert header chain

### DIFF
--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -255,9 +255,11 @@ func (c *Clique) VerifyHeader(chain consensus.ChainReader, header *types.Header,
 // VerifyHeaders is similar to VerifyHeader, but verifies a batch of headers. The
 // method returns a quit channel to abort the operations and a results channel to
 // retrieve the async verifications (the order is that of the input slice).
-func (c *Clique) VerifyHeaders(chain consensus.ChainReader, headers []*types.Header, validators []common.Address, seals []bool) (chan<- struct{}, <-chan error) {
+func (c *Clique) VerifyHeaders(chain consensus.ChainReader, data types.HeaderInsertDataBatch, seals []bool) (chan<- struct{}, <-chan error) {
 	abort := make(chan struct{})
-	results := make(chan error, len(headers))
+	results := make(chan error, len(data))
+
+	headers, _ := data.Split()
 
 	go func() {
 		for i, header := range headers {

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -255,7 +255,7 @@ func (c *Clique) VerifyHeader(chain consensus.ChainReader, header *types.Header,
 // VerifyHeaders is similar to VerifyHeader, but verifies a batch of headers. The
 // method returns a quit channel to abort the operations and a results channel to
 // retrieve the async verifications (the order is that of the input slice).
-func (c *Clique) VerifyHeaders(chain consensus.ChainReader, headers []*types.Header, seals []bool) (chan<- struct{}, <-chan error) {
+func (c *Clique) VerifyHeaders(chain consensus.ChainReader, headers []*types.Header, validators []common.Address, seals []bool) (chan<- struct{}, <-chan error) {
 	abort := make(chan struct{})
 	results := make(chan error, len(headers))
 

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -68,7 +68,7 @@ type Engine interface {
 	// concurrently. The method returns a quit channel to abort the operations and
 	// a results channel to retrieve the async verifications (the order is that of
 	// the input slice).
-	VerifyHeaders(chain ChainReader, headers []*types.Header, seals []bool) (chan<- struct{}, <-chan error)
+	VerifyHeaders(chain ChainReader, headers []*types.Header, validators []common.Address, seals []bool) (chan<- struct{}, <-chan error)
 
 	// VerifyUncles verifies that the given block's uncles conform to the consensus
 	// rules of a given engine.

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -68,7 +68,7 @@ type Engine interface {
 	// concurrently. The method returns a quit channel to abort the operations and
 	// a results channel to retrieve the async verifications (the order is that of
 	// the input slice).
-	VerifyHeaders(chain ChainReader, headers []*types.Header, validators []common.Address, seals []bool) (chan<- struct{}, <-chan error)
+	VerifyHeaders(chain ChainReader, data types.HeaderInsertDataBatch, seals []bool) (chan<- struct{}, <-chan error)
 
 	// VerifyUncles verifies that the given block's uncles conform to the consensus
 	// rules of a given engine.

--- a/consensus/dpos/dpos.go
+++ b/consensus/dpos/dpos.go
@@ -198,7 +198,7 @@ func (d *Dpos) verifyHeader(chain consensus.ChainReader, header *types.Header, v
 	}
 	var vGetter validatorHelper
 	if len(validators) != 0 {
-		vGetter = newVHelper(validators, header, d.db)
+		vGetter = newVHelper(validators, header)
 	} else {
 		vGetter = newDBVHelper(d.db, parent, header)
 	}
@@ -663,14 +663,12 @@ type validatorHelper interface {
 type vHelper struct {
 	validators []common.Address
 	header     *types.Header
-	db         ethdb.Database
 }
 
-func newVHelper(validators []common.Address, header *types.Header, db ethdb.Database) *vHelper {
+func newVHelper(validators []common.Address, header *types.Header) *vHelper {
 	return &vHelper{
 		validators: validators,
 		header:     header,
-		db:         db,
 	}
 }
 

--- a/consensus/dpos/dpos.go
+++ b/consensus/dpos/dpos.go
@@ -228,12 +228,12 @@ func (d *Dpos) VerifyHeaders(chain consensus.ChainReader, batch types.HeaderInse
 	go func() {
 		for i, header := range headers {
 			parents := headers[:i]
-			var validators []common.Address
-			if i != 0 {
-				validators = validatorsSet[i-1]
-			}
-			err := validateHeaderWithValidators(header)
+			err := validateHeaderWithValidators(header, validatorsSet[i])
 			if err != nil {
+				var validators []common.Address
+				if i != 0 {
+					validators = validatorsSet[i-1]
+				}
 				err = d.verifyHeader(chain, header, validators, parents, seals[i])
 			}
 			select {

--- a/consensus/dpos/dpos.go
+++ b/consensus/dpos/dpos.go
@@ -233,11 +233,6 @@ func (d *Dpos) VerifyHeaders(chain consensus.ChainReader, data types.HeaderInser
 				validators = validatorsSet[i-1]
 			}
 			err := d.verifyHeader(chain, header, validators, parents, seals[i])
-
-			// If validators have been changed, save the validators
-			if err == nil && (i == 0 || IsElectBlock(parents[i-1], header)) {
-				err = types.SaveValidators(validatorsSet[i], d.db)
-			}
 			select {
 			case <-abort:
 				return

--- a/consensus/dpos/dpos.go
+++ b/consensus/dpos/dpos.go
@@ -671,7 +671,6 @@ func makeMinedCntKey(epoch int64, addr common.Address) []byte {
 // and save the validators to db
 type validatorHelper interface {
 	getValidator() (common.Address, error)
-	saveValidators() error
 }
 
 // vHelper is the validatorHelper which gets info from validators
@@ -691,10 +690,6 @@ func newVHelper(validators []common.Address, header *types.Header, db ethdb.Data
 
 func (g *vHelper) getValidator() (common.Address, error) {
 	return lookupValidator(g.header.Time.Int64(), g.validators)
-}
-
-func (g *vHelper) saveValidators() error {
-	return types.SaveValidators(g.validators, g.db)
 }
 
 // dbVHelper get the validator for the header from database
@@ -733,14 +728,6 @@ func (g *dbVHelper) getValidator() (common.Address, error) {
 	}
 	g.validators = validators
 	return lookupValidator(g.header.Time.Int64(), validators)
-}
-
-func (g *dbVHelper) saveValidators() error {
-	validators, err := g.getValidators()
-	if err != nil {
-		return err
-	}
-	return types.SaveValidators(validators, g.db)
 }
 
 func (g *dbVHelper) getValidators() ([]common.Address, error) {

--- a/consensus/dpos/epoch_context.go
+++ b/consensus/dpos/epoch_context.go
@@ -226,13 +226,15 @@ func allDelegatorForValidators(ctx *types.DposContext, validators []common.Addre
 // lookupValidator returns the validator responsible for producing the block in the curTime.
 // If not a valid timestamp, an error is returned
 func (ec *EpochContext) lookupValidator(blockTime int64) (validator common.Address, err error) {
-	validator = common.Address{}
-	slot, err := calcBlockSlot(blockTime)
+	validators, err := ec.DposContext.GetValidators()
 	if err != nil {
 		return common.Address{}, err
 	}
-	// Get validators and the expected validator
-	validators, err := ec.DposContext.GetValidators()
+	return lookupValidator(blockTime, validators)
+}
+
+func lookupValidator(blockTime int64, validators []common.Address) (validator common.Address, err error) {
+	slot, err := calcBlockSlot(blockTime)
 	if err != nil {
 		return common.Address{}, err
 	}

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -108,8 +108,9 @@ func (ethash *Ethash) VerifyHeader(chain consensus.ChainReader, header *types.He
 // VerifyHeaders is similar to VerifyHeader, but verifies a batch of headers
 // concurrently. The method returns a quit channel to abort the operations and
 // a results channel to retrieve the async verifications.
-func (ethash *Ethash) VerifyHeaders(chain consensus.ChainReader, headers []*types.Header, validators []common.Address, seals []bool) (chan<- struct{}, <-chan error) {
+func (ethash *Ethash) VerifyHeaders(chain consensus.ChainReader, data types.HeaderInsertDataBatch, seals []bool) (chan<- struct{}, <-chan error) {
 	// If we're running a full engine faking, accept any input as valid
+	headers, _ := data.Split()
 	if ethash.config.PowMode == ModeFullFake || len(headers) == 0 {
 		abort, results := make(chan struct{}), make(chan error, len(headers))
 		for i := 0; i < len(headers); i++ {

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -108,7 +108,7 @@ func (ethash *Ethash) VerifyHeader(chain consensus.ChainReader, header *types.He
 // VerifyHeaders is similar to VerifyHeader, but verifies a batch of headers
 // concurrently. The method returns a quit channel to abort the operations and
 // a results channel to retrieve the async verifications.
-func (ethash *Ethash) VerifyHeaders(chain consensus.ChainReader, headers []*types.Header, seals []bool) (chan<- struct{}, <-chan error) {
+func (ethash *Ethash) VerifyHeaders(chain consensus.ChainReader, headers []*types.Header, validators []common.Address, seals []bool) (chan<- struct{}, <-chan error) {
 	// If we're running a full engine faking, accept any input as valid
 	if ethash.config.PowMode == ModeFullFake || len(headers) == 0 {
 		abort, results := make(chan struct{}), make(chan error, len(headers))

--- a/core/block_validator_test.go
+++ b/core/block_validator_test.go
@@ -66,7 +66,7 @@ func TestHeaderVerification(t *testing.T) {
 				_, results = engine.VerifyHeaders(chain, []*types.Header{headers[i]}, []bool{true})
 			} else {
 				engine := ethash.NewFakeFailer(headers[i].Number.Uint64())
-				_, results = engine.VerifyHeaders(chain, []*types.Header{headers[i]}, []bool{true})
+				_, results = engine.VerifyHeaders(chain, []*types.Header{headers[i]}, nil, []bool{true})
 			}
 			// Wait for the verification result
 			select {
@@ -122,7 +122,7 @@ func testHeaderConcurrentVerification(t *testing.T, threads int) {
 
 		if valid {
 			chain, _ := NewBlockChain(testdb, nil, params.DposChainConfig, dpos.NewDposFaker(), vm.Config{}, nil)
-			_, results = chain.engine.VerifyHeaders(chain, headers, seals)
+			_, results = chain.engine.VerifyHeaders(chain, headers, nil, seals)
 			chain.Stop()
 		}
 
@@ -188,7 +188,7 @@ func testHeaderConcurrentAbortion(t *testing.T, threads int) {
 	chain, _ := NewBlockChain(testdb, nil, params.DposChainConfig, dpos.NewDposFaker(), vm.Config{}, nil)
 	defer chain.Stop()
 
-	abort, results := chain.engine.VerifyHeaders(chain, headers, seals)
+	abort, results := chain.engine.VerifyHeaders(chain, headers, nil, seals)
 	close(abort)
 
 	// Deplete the results channel

--- a/core/block_validator_test.go
+++ b/core/block_validator_test.go
@@ -63,7 +63,7 @@ func TestHeaderVerification(t *testing.T) {
 
 			if valid {
 				engine := dpos.NewDposFaker()
-				_, results = engine.VerifyHeaders(chain, []*types.Header{headers[i]}, []bool{true})
+				_, results = engine.VerifyHeaders(chain, []*types.Header{headers[i]}, nil, []bool{true})
 			} else {
 				engine := ethash.NewFakeFailer(headers[i].Number.Uint64())
 				_, results = engine.VerifyHeaders(chain, []*types.Header{headers[i]}, nil, []bool{true})
@@ -122,7 +122,8 @@ func testHeaderConcurrentVerification(t *testing.T, threads int) {
 
 		if valid {
 			chain, _ := NewBlockChain(testdb, nil, params.DposChainConfig, dpos.NewDposFaker(), vm.Config{}, nil)
-			_, results = chain.engine.VerifyHeaders(chain, headers, nil, seals)
+			data := types.NewHeaderInsertDataBatch(headers, nil)
+			_, results = chain.engine.VerifyHeaders(chain, data, seals)
 			chain.Stop()
 		}
 
@@ -188,7 +189,8 @@ func testHeaderConcurrentAbortion(t *testing.T, threads int) {
 	chain, _ := NewBlockChain(testdb, nil, params.DposChainConfig, dpos.NewDposFaker(), vm.Config{}, nil)
 	defer chain.Stop()
 
-	abort, results := chain.engine.VerifyHeaders(chain, headers, nil, seals)
+	data := types.NewHeaderInsertDataBatch(headers, nil)
+	abort, results := chain.engine.VerifyHeaders(chain, data, seals)
 	close(abort)
 
 	// Deplete the results channel

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1656,9 +1656,9 @@ Error: %v
 // should be done or not. The reason behind the optional check is because some
 // of the header retrieval mechanisms already need to verify nonces, as well as
 // because nonces can be verified sparsely, not needing to check each.
-func (bc *BlockChain) InsertHeaderChain(chain []*types.Header, checkFreq int) (int, error) {
+func (bc *BlockChain) InsertHeaderChain(data types.HeaderInsertDataBatch, checkFreq int) (int, error) {
 	start := time.Now()
-	if i, err := bc.hc.ValidateHeaderChain(chain, checkFreq); err != nil {
+	if i, err := bc.hc.ValidateHeaderChain(data, checkFreq); err != nil {
 		return i, err
 	}
 
@@ -1669,15 +1669,18 @@ func (bc *BlockChain) InsertHeaderChain(chain []*types.Header, checkFreq int) (i
 	bc.wg.Add(1)
 	defer bc.wg.Done()
 
-	whFunc := func(header *types.Header) error {
+	whFunc := func(data types.HeaderInsertData) error {
 		bc.mu.Lock()
 		defer bc.mu.Unlock()
 
-		_, err := bc.hc.WriteHeader(header)
-		return err
+		_, err := bc.hc.WriteHeader(data.Header)
+		if err != nil {
+			return err
+		}
+		return bc.writeValidators(data.Validators)
 	}
 
-	return bc.hc.InsertHeaderChain(chain, whFunc, start)
+	return bc.hc.InsertHeaderChain(data, whFunc, start)
 }
 
 // writeHeader writes a header into the local chain, given that its parent is
@@ -1698,6 +1701,11 @@ func (bc *BlockChain) writeHeader(header *types.Header) error {
 
 	_, err := bc.hc.WriteHeader(header)
 	return err
+}
+
+// WriteValidators write validators to the underlying database
+func (bc *BlockChain) writeValidators(validators []common.Address) error {
+	return types.SaveValidators(validators, bc.db)
 }
 
 // CurrentHeader retrieves the current head header of the canonical chain. The

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1160,11 +1160,9 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 		headers[i] = block.Header()
 		seals[i] = verifySeals
 	}
-	abort, results := bc.engine.VerifyHeaders(bc, headers, nil, seals)
-	defer close(abort)
 
 	// Peek the error for the first block to decide the directing import logic
-	it := newInsertIterator(chain, results, bc.Validator())
+	it := newInsertIterator(bc, chain, bc.Validator(), bc.engine)
 
 	block, err := it.next()
 	switch {
@@ -1202,7 +1200,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 
 	// Some other error occurred, abort
 	case err != nil:
-		stats.ignored += len(it.chain)
+		stats.ignored += len(it.blocks)
 		bc.reportBlock(block, nil, err)
 		return it.index, events, coalescedLogs, err
 	}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1160,7 +1160,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 		headers[i] = block.Header()
 		seals[i] = verifySeals
 	}
-	abort, results := bc.engine.VerifyHeaders(bc, headers, seals)
+	abort, results := bc.engine.VerifyHeaders(bc, headers, nil, seals)
 	defer close(abort)
 
 	// Peek the error for the first block to decide the directing import logic

--- a/core/blockchain_insert.go
+++ b/core/blockchain_insert.go
@@ -19,10 +19,9 @@ package core
 import (
 	"time"
 
-	"github.com/DxChainNetwork/godx/consensus"
-
 	"github.com/DxChainNetwork/godx/common"
 	"github.com/DxChainNetwork/godx/common/mclock"
+	"github.com/DxChainNetwork/godx/consensus"
 	"github.com/DxChainNetwork/godx/core/types"
 	"github.com/DxChainNetwork/godx/log"
 )

--- a/core/blockchain_insert.go
+++ b/core/blockchain_insert.go
@@ -19,6 +19,8 @@ package core
 import (
 	"time"
 
+	"github.com/DxChainNetwork/godx/consensus"
+
 	"github.com/DxChainNetwork/godx/common"
 	"github.com/DxChainNetwork/godx/common/mclock"
 	"github.com/DxChainNetwork/godx/core/types"
@@ -80,43 +82,45 @@ func (st *insertStats) report(chain []*types.Block, index int, cache common.Stor
 
 // insertIterator is a helper to assist during chain import.
 type insertIterator struct {
-	chain     types.Blocks
-	results   <-chan error
+	chain     consensus.ChainReader
+	blocks    types.Blocks
 	index     int
 	validator Validator
+	engine    consensus.Engine
 }
 
 // newInsertIterator creates a new iterator based on the given blocks, which are
 // assumed to be a contiguous chain.
-func newInsertIterator(chain types.Blocks, results <-chan error, validator Validator) *insertIterator {
+func newInsertIterator(chain consensus.ChainReader, blocks types.Blocks, validator Validator, engine consensus.Engine) *insertIterator {
 	return &insertIterator{
 		chain:     chain,
-		results:   results,
+		blocks:    blocks,
 		index:     -1,
 		validator: validator,
+		engine:    engine,
 	}
 }
 
 // next returns the next block in the iterator, along with any potential validation
 // error for that block. When the end is reached, it will return (nil, nil).
 func (it *insertIterator) next() (*types.Block, error) {
-	if it.index+1 >= len(it.chain) {
-		it.index = len(it.chain)
+	if it.index+1 >= len(it.blocks) {
+		it.index = len(it.blocks)
 		return nil, nil
 	}
 	it.index++
-	if err := <-it.results; err != nil {
-		return it.chain[it.index], err
+	if err := it.engine.VerifyHeader(it.chain, it.blocks[it.index].Header(), true); err != nil {
+		return it.blocks[it.index], err
 	}
-	return it.chain[it.index], it.validator.ValidateBody(it.chain[it.index])
+	return it.blocks[it.index], it.validator.ValidateBody(it.blocks[it.index])
 }
 
 // current returns the current block that's being processed.
 func (it *insertIterator) current() *types.Block {
-	if it.index < 0 || it.index+1 >= len(it.chain) {
+	if it.index < 0 || it.index+1 >= len(it.blocks) {
 		return nil
 	}
-	return it.chain[it.index]
+	return it.blocks[it.index]
 }
 
 // previous returns the previous block was being processed, or nil
@@ -124,17 +128,17 @@ func (it *insertIterator) previous() *types.Block {
 	if it.index < 1 {
 		return nil
 	}
-	return it.chain[it.index-1]
+	return it.blocks[it.index-1]
 }
 
 // first returns the first block in the it.
 func (it *insertIterator) first() *types.Block {
-	return it.chain[0]
+	return it.blocks[0]
 }
 
 // remaining returns the number of remaining blocks.
 func (it *insertIterator) remaining() int {
-	return len(it.chain) - it.index
+	return len(it.blocks) - it.index
 }
 
 // processed returns the number of processed blocks.

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -228,7 +228,8 @@ func (hc *HeaderChain) ValidateHeaderChain(chain []*types.Header, checkFreq int)
 	}
 	seals[len(seals)-1] = true // Last should always be verified to avoid junk
 
-	abort, results := hc.engine.VerifyHeaders(hc, chain, nil, seals)
+	data := types.NewHeaderInsertDataBatch(chain, nil)
+	abort, results := hc.engine.VerifyHeaders(hc, data, seals)
 	defer close(abort)
 
 	// Iterate over the headers and ensure they all check out

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -228,7 +228,7 @@ func (hc *HeaderChain) ValidateHeaderChain(chain []*types.Header, checkFreq int)
 	}
 	seals[len(seals)-1] = true // Last should always be verified to avoid junk
 
-	abort, results := hc.engine.VerifyHeaders(hc, chain, seals)
+	abort, results := hc.engine.VerifyHeaders(hc, chain, nil, seals)
 	defer close(abort)
 
 	// Iterate over the headers and ensure they all check out

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -197,14 +197,20 @@ func (hc *HeaderChain) WriteHeader(header *types.Header) (status WriteStatus, er
 	return
 }
 
+// WriteValidators write validators to the underlying database
+func (hc *HeaderChain) WriteValidators(validators []common.Address) error {
+	return types.SaveValidators(validators, hc.chainDb)
+}
+
 // WhCallback is a callback function for inserting individual headers.
 // A callback is used for two reasons: first, in a LightChain, status should be
 // processed and light chain events sent, while in a BlockChain this is not
 // necessary since chain events are sent after inserting blocks. Second, the
 // header writes should be protected by the parent chain mutex individually.
-type WhCallback func(*types.Header) error
+type WhCallback func(data types.HeaderInsertData) error
 
-func (hc *HeaderChain) ValidateHeaderChain(chain []*types.Header, checkFreq int) (int, error) {
+func (hc *HeaderChain) ValidateHeaderChain(data types.HeaderInsertDataBatch, checkFreq int) (int, error) {
+	chain, _ := data.Split()
 	// Do a sanity check that the provided chain is actually ordered and linked
 	for i := 1; i < len(chain); i++ {
 		if chain[i].Number.Uint64() != chain[i-1].Number.Uint64()+1 || chain[i].ParentHash != chain[i-1].Hash() {
@@ -228,7 +234,6 @@ func (hc *HeaderChain) ValidateHeaderChain(chain []*types.Header, checkFreq int)
 	}
 	seals[len(seals)-1] = true // Last should always be verified to avoid junk
 
-	data := types.NewHeaderInsertDataBatch(chain, nil)
 	abort, results := hc.engine.VerifyHeaders(hc, data, seals)
 	defer close(abort)
 
@@ -260,27 +265,28 @@ func (hc *HeaderChain) ValidateHeaderChain(chain []*types.Header, checkFreq int)
 // should be done or not. The reason behind the optional check is because some
 // of the header retrieval mechanisms already need to verfy nonces, as well as
 // because nonces can be verified sparsely, not needing to check each.
-func (hc *HeaderChain) InsertHeaderChain(chain []*types.Header, writeHeader WhCallback, start time.Time) (int, error) {
+func (hc *HeaderChain) InsertHeaderChain(dataBatch types.HeaderInsertDataBatch, writeData WhCallback, start time.Time) (int, error) {
 	// Collect some import statistics to report on
 	stats := struct{ processed, ignored int }{}
 	// All headers passed verification, import them into the database
-	for i, header := range chain {
+	for i, data := range dataBatch {
 		// Short circuit insertion if shutting down
 		if hc.procInterrupt() {
 			log.Debug("Premature abort during headers import")
 			return i, errors.New("aborted")
 		}
 		// If the header's already known, skip it, otherwise store
-		if hc.HasHeader(header.Hash(), header.Number.Uint64()) {
+		if hc.HasHeader(data.Header.Hash(), data.Header.Number.Uint64()) {
 			stats.ignored++
 			continue
 		}
-		if err := writeHeader(header); err != nil {
+		if err := writeData(data); err != nil {
 			return i, err
 		}
 		stats.processed++
 	}
 	// Report some public statistics so the user has a clue what's going on
+	chain, _ := dataBatch.Split()
 	last := chain[len(chain)-1]
 
 	context := []interface{}{

--- a/core/types/dpos_context.go
+++ b/core/types/dpos_context.go
@@ -550,10 +550,18 @@ func (dc *DposContext) SetMinedCnt(minedCnt DposTrie)   { dc.minedCntTrie = mine
 
 // GetValidators retrieves validator list in current epoch
 func (dc *DposContext) GetValidators() ([]common.Address, error) {
+	return GetValidatorsFromDposTrie(dc.epochTrie)
+}
+
+// GetValidatorsFromDposTrie get the list of validators from the trie
+func GetValidatorsFromDposTrie(t DposTrie) ([]common.Address, error) {
 	var validators []common.Address
-	validatorsRLP, err := dc.epochTrie.TryGet(keyValidator)
+	validatorsRLP, err := t.TryGet(keyValidator)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get validator: %v", err)
+	}
+	if len(validatorsRLP) == 0 {
+		return nil, fmt.Errorf("empty value for validators, make sure opening the epoch trie")
 	}
 	if err := rlp.DecodeBytes(validatorsRLP, &validators); err != nil {
 		return nil, fmt.Errorf("failed to decode validators: %s", err)

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -169,7 +169,7 @@ type LightChain interface {
 	GetTd(common.Hash, uint64) *big.Int
 
 	// InsertHeaderChain inserts a batch of headers into the local chain.
-	InsertHeaderChain([]*types.Header, int) (int, error)
+	InsertHeaderChain(types.HeaderInsertDataBatch, int) (int, error)
 
 	// Rollback removes a few recently added elements from the local chain.
 	Rollback([]common.Hash)

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -200,9 +200,11 @@ func (dl *downloadTester) GetTd(hash common.Hash, number uint64) *big.Int {
 }
 
 // InsertHeaderChain injects a new batch of headers into the simulated chain.
-func (dl *downloadTester) InsertHeaderChain(headers []*types.Header, checkFreq int) (i int, err error) {
+func (dl *downloadTester) InsertHeaderChain(data types.HeaderInsertDataBatch, checkFreq int) (i int, err error) {
 	dl.lock.Lock()
 	defer dl.lock.Unlock()
+
+	headers, _ := data.Split()
 
 	// Do a quick check, as the blockchain.InsertHeaderChain doesn't insert anything in case of errors
 	if _, ok := dl.ownHeaders[headers[0].ParentHash]; !ok {

--- a/les/handler.go
+++ b/les/handler.go
@@ -78,7 +78,7 @@ type BlockChain interface {
 	State() (*state.StateDB, error)
 	DposCtx() (*types.DposContext, error)
 	DposCtxAt(*types.DposContextRoot) (*types.DposContext, error)
-	InsertHeaderChain(chain []*types.Header, checkFreq int) (int, error)
+	InsertHeaderChain(chain types.HeaderInsertDataBatch, checkFreq int) (int, error)
 	Rollback(chain []common.Hash)
 	GetHeaderByNumber(number uint64) *types.Header
 	GetAncestor(hash common.Hash, number, ancestor uint64, maxNonCanonical *uint64) (common.Hash, uint64)

--- a/light/lightchain.go
+++ b/light/lightchain.go
@@ -386,7 +386,7 @@ func (self *LightChain) InsertHeaderChain(data types.HeaderInsertDataBatch, chec
 		defer self.mu.Unlock()
 
 		header := data.Header
-		status, err := self.hc.WriteHeader(data.Header)
+		status, err := self.hc.WriteHeader(header)
 
 		switch status {
 		case core.CanonStatTy:


### PR DESCRIPTION
### Description

1. Refactored dpos.verifySeal function.
2. Added verify seal to dpos.verifyHeader and dpos.VerifyHeaders
3. Changed signature InsertHeaderChain for all related interface and implementation. Replace []*types.Header to types.HeaderInsertDataBatch. Change related codes as necessary.
4. Updated blockchain.InsertChain code. verifyHeader called after the last block is inserted.